### PR TITLE
Update CODEOWNERS to remove a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
-*                                               @hiero-ledger/github-maintainers @hiero-ledger/hiero-contracts-maintainers @hiero-ledger/hiero-contracts-committers 
+*                                               @hiero-ledger/github-maintainers @hiero-ledger/hiero-contracts-maintainers


### PR DESCRIPTION
Removed '@hiero-ledger/hiero-contracts-committers' from global protection rule.


