### PR TITLE
chore: triggering github actions (#3)

### DIFF
--- a/.github/scripts/check-pr.js
+++ b/.github/scripts/check-pr.js
@@ -118,9 +118,6 @@ async function checkPRLabelsAndMilestone(pr) {
     if (!prLabels || prLabels.length === 0) {
         throw new Error('The PR has no labels.');
     }
-    if (!prMilestone) {
-        throw new Error('The PR has no milestone.');
-    }
 }
 
 function isDependabotOrSnykPR(pr) {
@@ -143,9 +140,6 @@ async function processIssueReferencesInText(text) {
 
                     if (!issueLabels || issueLabels.length === 0) {
                         throw new Error(`Associated issue #${issueRef.issueNumber} has no labels.`);
-                    }
-                    if (!issueMilestone) {
-                        throw new Error(`Associated issue #${issueRef.issueNumber} has no milestone.`);
                     }
                 }
             } else {
@@ -227,11 +221,6 @@ async function processReferencedPR(prRef, contributors) {
                     if (!issueLabels || issueLabels.length === 0) {
                         throw new Error(
                             `Associated issue #${issueRef.issueNumber} has no labels.`
-                        );
-                    }
-                    if (!issueMilestone) {
-                        throw new Error(
-                            `Associated issue #${issueRef.issueNumber} has no milestone.`
                         );
                     }
                 }

--- a/.github/scripts/forward-ports.sh
+++ b/.github/scripts/forward-ports.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Built-in SOLO port forwarding does not work :/
+# Port forwarding stops shortly after a one-shot Falcon start in GitHub actions.
+# For this reason, we use this script to start port forwarding directly via Bash,
+# instead of relying on the Node.js script.
+# This approach keeps the connection stable and ensures it lasts throughout the tests.
+
+FORWARDS=(
+  "mirror-1-rest|5551"
+  "network-node1|50211"
+  "relay-1|7546"
+  "mirror-1-grpc|5600"
+)
+
+ps aux | grep "port-forward" | grep kubectl | awk '{print $2}' | xargs -r kill -9
+NS="$(kubectl get ns -o name | sed 's|^namespace/||' | grep '^solo' | grep -v '^solo-setup$' | head -n1)"
+
+listen() {
+  local pod="$1"
+  local port="$2"
+  (
+    while true; do
+      if ! ps aux | grep -F kubectl | grep -F port-forward | grep -F " ${port}:${port}" | grep -v grep >/dev/null; then
+        kubectl port-forward "$pod" -n "$NS" "${port}:${port}" >/dev/null 2>&1 &
+      fi
+      sleep 1
+    done
+  ) &
+}
+
+for row in "${FORWARDS[@]}"; do
+  IFS='|' read -r include port <<<"$row"
+  POD="$(kubectl get pods -A --no-headers | grep -E "$include" | head -n 1 | awk '{print $2}' | head -n1)"
+  listen "$POD" "$port"
+done

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -15,6 +15,9 @@ on:
       relayTag:
         required: false
         type: string
+      soloVersion:
+        required: false
+        type: string
 
 defaults:
   run:
@@ -53,7 +56,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
-          #cache: npm Disabling this because it causes the workflow to hang and eventually timeout
 
       - name: Create .env file
         run: cp .env.example .env
@@ -79,7 +81,9 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-          
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.144.0' }}"
+            --force-port-forward: true
+
           explorerNode:
             --enable-ingress: true
           
@@ -87,9 +91,25 @@ jobs:
             --node-aliases: "node1"
           EOF
 
-      - name: Start the local node
-        run: npx @hashgraph/solo one-shot falcon deploy --values-file falcon.yml
-        timeout-minutes: 5
+      - name: Setup Kind
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          install_only: true
+          node_image: kindest/node:v1.32.5@sha256:e3b2327e3a5ab8c76f5ece68936e4cafaa82edf58486b769727ab0b3b97a5b0d
+          version: v0.29.0
+          kubectl_version: v1.32.5
+          verbosity: 3
+          wait: 120s
+
+      - name: Start the solo node
+        run: npx @hashgraph/solo@${{ inputs.soloVersion || '0.52.0' }} one-shot falcon deploy --values-file .github/falcon.yml
+        timeout-minutes: 15
+
+      - name: Forward solo ports
+        run: .github/scripts/forward-ports.sh
+
+      - name: Initialize test environment variables
+        run: cp local.env .env
 
       - name: Run the test in ${{ inputs.testfilter }}
         run: npx hardhat test --grep ${{ inputs.testfilter }}
@@ -110,6 +130,6 @@ jobs:
           json_thousands_separator: ','
           files: 'test-*.xml'
 
-      - name: Stop the local node
+      - name: Stop solo
         if: ${{ !cancelled() }}
-        run: npx @hashgraph/solo one-shot single destroy
+        run: npx @hashgraph/solo@${{ inputs.soloVersion || '0.52.0' }} one-shot single destroy


### PR DESCRIPTION
**Description**:

Changes I had to make to the pipelines in order to make solo node work correctly in GitHub actions.

Port forwarding triggered automatically by one-shot falcon configuration is (for still unknown to me reasons) not durable.

So, please run kubectl port-forward directly to ensure the ports are exposed. I also monitor the port-forwarding processes to make sure they don’t get shut down in the middle of the tests.


**Related issue(s)**:

Fixes #3

**Notes for reviewer**:

I also turned off milestones checks since we have no milestones yet in this project! @Ferparishuertas 

**Alternatives**:

Since the port-forwarding durability issues only occur in pipelines, I suspect they may be related to the resources assigned to the runner. We can try running the tests on a more powerful machine. If the problem still occurs, I propose reaching out to the team responsible for maintaining the solo-node setup. Debugging this further is quite time-consuming, and I don’t think I’ll be able to come up with a better solution than the one proposed here.

We can also just keep using the local node instead of solo - everything works fine then...

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
