### PR TITLE
chore: upgrade node version in CIs to be compatible with Hardhat 3

### DIFF
--- a/.github/scripts/check-pr.js
+++ b/.github/scripts/check-pr.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+import axios from 'axios';
 
 const githubToken = process.env.GITHUB_TOKEN;
 const { GITHUB_REPOSITORY, GITHUB_PR_NUMBER } = process.env;

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -47,10 +47,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Use Node.js [20]
+      - name: Use Node.js [24]
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 24.12.0
 
       - name: Create .env file
         run: cp .env.example .env


### PR DESCRIPTION
**Description**:

In order for hardhat 3 to work correctly in github actions we need to use newer nodejs version and use imports in check-pr.js.

**Related issue(s)**:

Fixes #15

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
