### PR TITLE
fix: close hapi connection after transfer test (#43)

### DIFF
--- a/test/token-service/token-transfer/tokenTransferContract.js
+++ b/test/token-service/token-transfer/tokenTransferContract.js
@@ -75,6 +75,10 @@ describe('TokenTransferContract Test Suite', function () {
     await utils.grantTokenKyc(tokenCreateContract, nftTokenAddress);
   });
 
+  after(function () {
+    hapi.client.close();
+  });
+
   it('should NOT be able to use transferFrom on fungible tokens without approval', async function () {
     const amount = 1;
     try {


### PR DESCRIPTION
**Description**:
Close the hapi client connection after transfer test.

**Related issue(s)**:

Fixes #43

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
