### PR TITLE
feat: use previous name for github token again (#50)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           checkout: 'true'
           checkout-ref: '${{ github.ref }}'
-          checkout-token: '${{ secrets.GH_ACCESS_TOKEN }}'
+          checkout-token: '${{ secrets.GITHUB_TOKEN }}'
           setup-node: 'true'
           node-version: '24.12.0'
           node-registry: 'https://registry.npmjs.org/'
@@ -92,7 +92,7 @@ jobs:
         id: calculate-version
         working-directory: contracts
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_USER_NAME }}
@@ -196,7 +196,7 @@ jobs:
         with:
           checkout: 'true'
           checkout-ref: '${{ github.ref }}'
-          checkout-token: '${{ secrets.GH_ACCESS_TOKEN }}'
+          checkout-token: '${{ secrets.GITHUB_TOKEN }}'
           setup-node: 'true'
           node-version: '24.12.0'
           node-registry: 'https://registry.npmjs.org/'
@@ -247,7 +247,7 @@ jobs:
 
       - name: Publish Semantic Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_USER_NAME }}
@@ -315,7 +315,7 @@ jobs:
         with:
           milestone_name: ${{ needs.prepare-release.outputs.version }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   create-snapshot-pr:
     name: Release / Snapshot
@@ -334,7 +334,7 @@ jobs:
         with:
           checkout: 'true'
           checkout-ref: '${{ github.event.repository.default_branch }}'
-          checkout-token: '${{ secrets.GH_ACCESS_TOKEN }}'
+          checkout-token: '${{ secrets.GITHUB_TOKEN }}'
           setup-node: 'true'
           node-version: '24.12.0'
           node-registry: 'https://registry.npmjs.org/'
@@ -390,7 +390,7 @@ jobs:
           title: ${{ env.PR_TITLE }}
           milestone: ${{ env.MILESTONE }}
           labels: 'process'
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-npm-package:
     name: Release / Publish Hiero Contracts NPM package
@@ -405,7 +405,7 @@ jobs:
         with:
           checkout: 'true'
           checkout-ref: '${{ github.ref }}'
-          checkout-token: '${{ secrets.GH_ACCESS_TOKEN }}'
+          checkout-token: '${{ secrets.GITHUB_TOKEN }}'
           setup-node: 'true'
           node-version: '24.12.0'
           node-registry: 'https://registry.npmjs.org/'


### PR DESCRIPTION
**Description**:
Rename GH_ACTION_TOKEN to GITHUB_TOKEN.

This is the name we are currently using in our configuration.

**Related issue(s)**:

Fixes #50

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
