### PR TITLE
feat: fixes after getting correct privileges (#50)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,20 +62,23 @@ jobs:
         id: release_mode
         run: |
           if [[ "${RELEASE_TYPE}" == "rc" ]]; then
-            echo "semrel_config=.releaserc.rc" >> "${GITHUB_OUTPUT}"
+            echo "semrel_config=.releaserc.rc.json" >> "${GITHUB_OUTPUT}"
             echo "npm_dist_tag=rc" >> "${GITHUB_OUTPUT}"
             echo "::notice::Using RC release mode"
           else
-            echo "semrel_config=.releaserc" >> "${GITHUB_OUTPUT}"
+            echo "semrel_config=.releaserc.json" >> "${GITHUB_OUTPUT}"
             echo "npm_dist_tag=latest" >> "${GITHUB_OUTPUT}"
             echo "::notice::Using standard release mode"
           fi
 
       - name: Install Semantic Release
+        working-directory: contracts
         run: |
-          npm install -g semantic-release@25.0.2 @semantic-release/git@10.0.1 @semantic-release/github@12.0.2 @semantic-release/exec@7.1.0 gradle-semantic-release-plugin@1.7.6
-          npm install -g conventional-changelog-conventionalcommits@9.1.0 @commitlint/cli@18.6.0 @commitlint/config-conventional@18.6.0
-          npm install -g marked-mangle@1.1.6 marked-gfm-heading-id@3.1.2 semantic-release-conventional-commits@3.0.0
+          npm install \
+            semantic-release@25.0.2 @semantic-release/git@10.0.1 @semantic-release/github@12.0.2 \
+            @semantic-release/exec@7.1.0 @commitlint/config-conventional@18.6.0 @commitlint/cli@18.6.0 \
+            marked-mangle@1.1.6 marked-gfm-heading-id@3.1.2 conventional-changelog-conventionalcommits@9.1.0 \
+            @semantic-release/commit-analyzer@13.0.1
 
       - name: Create RC semantic-release config when started against non-rc branch (like main).
         if: ${{ github.event.repository.default_branch == github.ref_name && inputs.release-type == 'rc' }}
@@ -83,9 +86,9 @@ jobs:
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          jq --arg branch "${DEFAULT_BRANCH}" '.branches = [{"name":$branch,"prerelease":"rc"}]' .releaserc > .releaserc.rc
-          echo "::group::.releaserc.rc"
-          cat .releaserc.rc
+          jq --arg branch "${DEFAULT_BRANCH}" '.branches = [{"name":$branch,"prerelease":"rc"}]' .releaserc.json > .releaserc.rc.json
+          echo "::group::.releaserc.rc.json"
+          cat .releaserc.rc.json
           echo "::endgroup::"
 
       - name: Calculate Next Version
@@ -101,7 +104,7 @@ jobs:
           PROCEED="true"
           SEMREL_OUTPUT=""
           if [[ "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]]; then
-            if SEMREL_OUTPUT=$(npx semantic-release --dry-run --extends "${{ steps.release_mode.outputs.semrel_config }}" 2>&1); then
+            if SEMREL_OUTPUT=$(npx semantic-release --dry-run --extends "./${{ steps.release_mode.outputs.semrel_config }}" 2>&1); then
               if echo "${SEMREL_OUTPUT}" | grep -q "The next release version is"; then
                 echo "::notice::Semantic Release detected a new version"
                 NEXT_VER=$(echo "${SEMREL_OUTPUT}" | sed -n 's/.*The next release version is \([^[:space:]]*\).*/\1/p' | head -n1)
@@ -225,10 +228,13 @@ jobs:
 
       - name: Install Semantic Release
         if: ${{ github.event.repository.default_branch == github.ref_name }}
+        working-directory: contracts
         run: |
-          npm install -g semantic-release@25.0.2 @semantic-release/git@10.0.1 @semantic-release/github@12.0.2 @semantic-release/exec@7.1.0 gradle-semantic-release-plugin@1.7.6
-          npm install -g conventional-changelog-conventionalcommits@9.1.0 @commitlint/cli@18.6.0 @commitlint/config-conventional@18.6.0
-          npm install -g marked-mangle@1.1.6 marked-gfm-heading-id@3.1.2 semantic-release-conventional-commits@3.0.0
+          npm install \
+            semantic-release@25.0.2 @semantic-release/git@10.0.1 @semantic-release/github@12.0.2 \
+            @semantic-release/exec@7.1.0 @commitlint/config-conventional@18.6.0 @commitlint/cli@18.6.0 \
+            marked-mangle@1.1.6 marked-gfm-heading-id@3.1.2 conventional-changelog-conventionalcommits@9.1.0 \
+            @semantic-release/commit-analyzer@13.0.1
 
       # Install deps so the custom bump script can run as part of semantic-release
       - name: Install dependencies
@@ -240,9 +246,9 @@ jobs:
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          jq --arg branch "${DEFAULT_BRANCH}" '.branches = [{"name":$branch,"prerelease":"rc"}]' .releaserc > .releaserc.rc
-          echo "::group::.releaserc.rc"
-          cat .releaserc.rc
+          jq --arg branch "${DEFAULT_BRANCH}" '.branches = [{"name":$branch,"prerelease":"rc"}]' .releaserc.json > .releaserc.rc.json
+          echo "::group::.releaserc.rc.json"
+          cat .releaserc.rc.json
           echo "::endgroup::"
 
       - name: Publish Semantic Release
@@ -338,7 +344,7 @@ jobs:
           setup-node: 'true'
           node-version: '24.12.0'
           node-registry: 'https://registry.npmjs.org/'
-      
+
       - name: Install GnuPG Tools
         run: |
           if ! command -v gpg2 >/dev/null 2>&1; then

--- a/contracts/.releaserc.json
+++ b/contracts/.releaserc.json
@@ -7,8 +7,8 @@
       "range": "${name.replace(/release\\//g, '').split('.')[0]}.${name.replace(/release\\//g, '').split('.')[1]}.x"
     },
     {
-      "name": "rc/*",
-      "prerelease": "rc",
+      "name": "rc",
+      "prerelease": "${name}",
       "channel": "rc"
     }
   ],


### PR DESCRIPTION
**Description**:

Addressing two issues I've noticed after updates:
1. .releaserc & .releaserc.rc need to have an extension (.json) or semver tries to load it as a module and fails...
2. semver for some unknown reason fails to load the modules if it's not installed locally from the ./contracts directory. That's why I changed global install to the local one .
3. in release rc each version needs unique prerelease flag. So {rc/*} name and rc prerelease won't work together since rc/* can represent any number of releases...

**Related issue(s)**:

Fixes #50

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
