### PR TITLE
chore: use github username and email from vars instead of secrets (#50)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,10 +96,10 @@ jobs:
         working-directory: contracts
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
-          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
-          GIT_COMMITTER_NAME: ${{ secrets.GIT_USER_NAME }}
-          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
+          GIT_AUTHOR_NAME: ${{ vars.GIT_USER_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ vars.GIT_USER_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ vars.GIT_USER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ vars.GIT_USER_EMAIL }}
         run: |
           PROCEED="true"
           SEMREL_OUTPUT=""
@@ -254,10 +254,10 @@ jobs:
       - name: Publish Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
-          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
-          GIT_COMMITTER_NAME: ${{ secrets.GIT_USER_NAME }}
-          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
+          GIT_AUTHOR_NAME: ${{ vars.GIT_USER_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ vars.GIT_USER_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ vars.GIT_USER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ vars.GIT_USER_EMAIL }}
         if: ${{ github.event.repository.default_branch == github.ref_name }}
         working-directory: contracts
         run: |


### PR DESCRIPTION
**Description**:

Use github username and email from vars insted of secrets

**Related issue(s)**:

Fixes #50

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
