### PR TITLE
chore: make rc release work (#50)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          jq --arg branch "${DEFAULT_BRANCH}" '.branches = [{"name":$branch,"prerelease":"rc"}]' .releaserc.json > .releaserc.tmp.json
+          jq --arg branch "${DEFAULT_BRANCH}" '.branches = [{"name":$branch,"prerelease":"rc"},"fakerelease"]' .releaserc.json > .releaserc.tmp.json
           mv .releaserc.tmp.json .releaserc.json
           echo "::group::.releaserc.json"
           cat .releaserc.json
@@ -244,7 +244,7 @@ jobs:
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          jq --arg branch "${DEFAULT_BRANCH}" '.branches = [{"name":$branch,"prerelease":"rc"}]' .releaserc.json > .releaserc.tmp.json
+          jq --arg branch "${DEFAULT_BRANCH}" '.branches = [{"name":$branch,"prerelease":"rc"},"fakerelease"]' .releaserc.json > .releaserc.tmp.json
           mv .releaserc.tmp.json .releaserc.json
           echo "::group::.releaserc.json"
           cat .releaserc.json


### PR DESCRIPTION
**Description**:

It makes the rc release works, by satisfying the semrel requirements to have at least one non-rc release branch configured.


**It requires the fake branch name used here "fakerelease" to never be removed!**

**Related issue(s)**:

Fixes #50

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
