### PR TITLE
chore: add MAINTAINERS.md to document maintainer roles

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,42 @@
+# Maintainers
+
+The general handling of Maintainer rights and all groups in this GitHub org is done in the https://github.com/hiero-ledger/governance repository.
+
+## Maintainer Scopes, GitHub Roles and GitHub Teams
+
+Maintainers are assigned the following scopes in this repository:
+
+|        Scope        |            Definition             | GitHub Role |      GitHub Team      |
+|---------------------|-----------------------------------|-------------|-----------------------|
+| project-maintainers | The Maintainers of the project    | Maintain    | `hiero-maintainers`   |
+| tsc                 | The Hiero TSC                     | Maintain    | `tsc`                 |
+| github-maintainers  | The Maintainers of the github org | Maintain    | `github-maintainers`  |
+
+## Active Maintainers
+
+<!-- Please keep this sorted alphabetically by github -->
+
+| Name                         | GitHub ID               | Scope | LFID | Discord ID | Email | Company Affiliation  |
+|----------------------------- | ----------------------- | ----- | ---- | ---------- | ----- | -------------------- |
+| Fernando Paris               | Ferparishuertas         |       |      |            |       | Hashgraph            |
+| Lyuben Ivanov                | bubo                    |       |      |            |       | LimeChain            |
+| Glib Kozyryatskyy            | gkozyryatskyy           |       |      |            |       |                      |
+| Stanimir Stoyanov            | stoyanov-st             |       |      |            |       | Hashgraph            |
+| Nana Essilfie-Conduah        | Nana-EC                 |       |      |            |       | Hashgraph            |
+| Luke Lee                     | lukelee-sl              |       |      |            |       | Hashgraph            |
+| Lukasz Gasior                | lukasz-hashgraph        |       |      |            |       | Hashgraph            |
+| Luis Mastrangelo             | acuarica                |       |      |            |       | Hashgraph            |
+| Nikolay Atanasow             | natanasow               |       |      |            |       | LimeChain            |
+| Simeon Nakov                 | simzzz                  |       |      |            |       | LimeChain            |
+| Konstantina Blazhukova       | konstantinabl           |       |      |            |       | LimeChain            |
+| Logan Nguyen                 | quiet-node              |       |      |            |       | Hashgraph            |
+
+## Emeritus Maintainers
+
+| Name             | GitHub ID     | Scope               | LFID | Discord ID | Email | Company Affiliation  |
+|----------------- | ------------- | ------------------- | ---- | ---------- | ----- | -------------------- |
+| George Spasov    | Perseverance  | project-maintainers |      |            |       | Limechain            |
+
+## The Duties of a Maintainer
+
+Maintainers are expected to perform duties in alignment with **[Hiero-Ledger's defined maintainer guidelines](https://github.com/hiero-ledger/.github/blob/main/CONTRIBUTING.md#about-users-and-maintainers).**


### PR DESCRIPTION
This document outlines the roles, scopes, and responsibilities of maintainers within the project, including a list of active and emeritus maintainers.

