### PR TITLE
fix: correct isAuthorizedRaw return type from (int64,bool) to (bool)

### DIFF
--- a/contracts/account-service/IHRC632.sol
+++ b/contracts/account-service/IHRC632.sol
@@ -22,17 +22,19 @@ interface IHRC632 {
     function isValidAlias(address addr) external returns (bool response);
 
     /// Determines if the signature is valid for the given message hash and account.
-    /// It is assumed that the signature is composed of a single EDCSA or ED25519 key.
+    /// It is assumed that the signature is composed of a single ECDSA or ED25519 key.
+    /// Unlike `isAuthorized`, this returns a bare `bool` — the precompile returns
+    /// BOOL, not RESPONSE_CODE64_BOOL, because it performs a pure signature check
+    /// without the heavier authorization flow.
     /// @param account The account to check the signature against.
     /// @param messageHash The hash of the message to check the signature against.
     /// @param signature The signature to check.
-    /// @return responseCode The response code for the status of the request.  SUCCESS is 22.
     /// @return authorized True if the signature is valid, false otherwise.
     function isAuthorizedRaw(
         address account,
         bytes memory messageHash,
         bytes memory signature
-    ) external returns (int64 responseCode, bool authorized);
+    ) external returns (bool authorized);
 
     /// Determines if the signature is valid for the given message  and account.
     /// It is assumed that the signature is composed of a possibly complex cryptographic key.


### PR DESCRIPTION
Fixes #126

The precompile for `isAuthorizedRaw` returns a bare `BOOL` (`bool`), not `RESPONSE_CODE64_BOOL` (`int64, bool`). This was verified against the consensus node across all IHRC632 functions — only `isAuthorizedRaw` had the mismatch (see issue #126 for the full comparison table).

This PR:
- Changes the return type from `(int64 responseCode, bool authorized)` to `(bool authorized)`
- Updates the NatSpec to explain why this function differs from `isAuthorized`
- Also fixes `EDCSA` → `ECDSA` typo in the same doc comment
