### PR TITLE
fix: convert HRC-904 example doc tags from // to /// for NatSpec

### DIFF
--- a/contracts/extensions/hrc-904/Airdrop.sol
+++ b/contracts/extensions/hrc-904/Airdrop.sol
@@ -6,25 +6,25 @@ import {HederaTokenService} from "../../token-service/HederaTokenService.sol";
 import {IHederaTokenService} from "../../token-service/IHederaTokenService.sol";
 pragma experimental ABIEncoderV2;
 
-// @title Airdrop Contract
-// @notice Facilitates token airdrops for both fungible and non-fungible tokens
-// @dev Implements HRC-904 standard for token airdrops
-//
-// Recipients will receive tokens in one of these ways:
-// - Immediately if already associated with the token
-// - Immediately with auto-association if they have available slots
-// - As a pending airdrop requiring claim if they have "receiver signature required"
-// - As a pending airdrop requiring claim if they have no available auto-association slots
-//
-// All transfer fees and auto-renewal rent costs are charged to the transaction submitter
+/// @title Airdrop Contract
+/// @notice Facilitates token airdrops for both fungible and non-fungible tokens
+/// @dev Implements HRC-904 standard for token airdrops
+///
+/// Recipients will receive tokens in one of these ways:
+/// - Immediately if already associated with the token
+/// - Immediately with auto-association if they have available slots
+/// - As a pending airdrop requiring claim if they have "receiver signature required"
+/// - As a pending airdrop requiring claim if they have no available auto-association slots
+///
+/// All transfer fees and auto-renewal rent costs are charged to the transaction submitter
 contract Airdrop is HederaTokenService {
-    // @notice Airdrops a fungible token from a sender to a single receiver
-    // @dev Builds airdrop struct and submits airdropTokens system contract call
-    // @param token The token address to airdrop
-    // @param sender The address sending the tokens
-    // @param receiver The address receiving the tokens
-    // @param amount The amount of tokens to transfer
-    // @return responseCode The response code from the airdrop operation (22 = success)
+    /// @notice Airdrops a fungible token from a sender to a single receiver
+    /// @dev Builds airdrop struct and submits airdropTokens system contract call
+    /// @param token The token address to airdrop
+    /// @param sender The address sending the tokens
+    /// @param receiver The address receiving the tokens
+    /// @param amount The amount of tokens to transfer
+    /// @return responseCode The response code from the airdrop operation (22 = success)
     function tokenAirdrop(address token, address sender, address receiver, int64 amount) public payable returns (int64 responseCode) {
         IHederaTokenService.TokenTransferList[] memory tokenTransfers = new IHederaTokenService.TokenTransferList[](1);
         IHederaTokenService.TokenTransferList memory airdrop;
@@ -39,13 +39,13 @@ contract Airdrop is HederaTokenService {
         return responseCode;
     }
 
-    // @notice Airdrops a non-fungible token from a sender to a single receiver
-    // @dev Builds NFT airdrop struct and submits airdropTokens system contract call
-    // @param token The NFT token address
-    // @param sender The address sending the NFT
-    // @param receiver The address receiving the NFT
-    // @param serial The serial number of the NFT to transfer
-    // @return responseCode The response code from the airdrop operation (22 = success)
+    /// @notice Airdrops a non-fungible token from a sender to a single receiver
+    /// @dev Builds NFT airdrop struct and submits airdropTokens system contract call
+    /// @param token The NFT token address
+    /// @param sender The address sending the NFT
+    /// @param receiver The address receiving the NFT
+    /// @param serial The serial number of the NFT to transfer
+    /// @return responseCode The response code from the airdrop operation (22 = success)
     function nftAirdrop(address token, address sender, address receiver, int64 serial) public payable returns (int64 responseCode) {
         IHederaTokenService.TokenTransferList[] memory tokenTransfers = new IHederaTokenService.TokenTransferList[](1);
         IHederaTokenService.TokenTransferList memory airdrop;
@@ -63,13 +63,13 @@ contract Airdrop is HederaTokenService {
         return responseCode;
     }
 
-    // @notice Airdrops multiple fungible tokens of the same amount from a sender to a single receiver
-    // @dev Builds multiple token transfer structs and submits a single airdropTokens system contract call
-    // @param tokens Array of token addresses to airdrop
-    // @param sender The address sending all tokens
-    // @param receiver The address receiving all tokens
-    // @param amount The amount of each token to transfer
-    // @return responseCode The response code from the airdrop operation (22 = success)
+    /// @notice Airdrops multiple fungible tokens of the same amount from a sender to a single receiver
+    /// @dev Builds multiple token transfer structs and submits a single airdropTokens system contract call
+    /// @param tokens Array of token addresses to airdrop
+    /// @param sender The address sending all tokens
+    /// @param receiver The address receiving all tokens
+    /// @param amount The amount of each token to transfer
+    /// @return responseCode The response code from the airdrop operation (22 = success)
     function multipleFtAirdrop(address[] memory tokens, address sender, address receiver, int64 amount) public payable returns (int64 responseCode) {
         uint256 length = tokens.length;
         IHederaTokenService.TokenTransferList[] memory tokenTransfers = new IHederaTokenService.TokenTransferList[](length);
@@ -87,13 +87,13 @@ contract Airdrop is HederaTokenService {
         return responseCode;
     }
 
-    // @notice Airdrops multiple NFTs from a sender to a single receiver
-    // @dev Builds multiple NFT transfer structs and submits a single airdropTokens system contract call
-    // @param nfts Array of NFT token addresses
-    // @param sender The address sending all NFTs
-    // @param receiver The address receiving all NFTs
-    // @param serials Array of serial numbers corresponding to each NFT
-    // @return responseCode The response code from the airdrop operation (22 = success)
+    /// @notice Airdrops multiple NFTs from a sender to a single receiver
+    /// @dev Builds multiple NFT transfer structs and submits a single airdropTokens system contract call
+    /// @param nfts Array of NFT token addresses
+    /// @param sender The address sending all NFTs
+    /// @param receiver The address receiving all NFTs
+    /// @param serials Array of serial numbers corresponding to each NFT
+    /// @return responseCode The response code from the airdrop operation (22 = success)
     function multipleNftAirdrop(address[] memory nfts, address sender, address receiver, int64[] memory serials) public returns (int64 responseCode) {
         uint256 length = nfts.length;
         IHederaTokenService.TokenTransferList[] memory tokenTransfers = new IHederaTokenService.TokenTransferList[](length);
@@ -113,13 +113,13 @@ contract Airdrop is HederaTokenService {
         return responseCode;
     }
 
-    // @notice Distributes the same amount of a fungible token from one sender to multiple receivers
-    // @dev Optimizes gas by building a single transfer list with multiple receivers
-    // @param token The token address to distribute
-    // @param sender The address sending the tokens
-    // @param receivers Array of addresses to receive the tokens
-    // @param amount The amount each receiver should get
-    // @return responseCode The response code from the airdrop operation (22 = success)
+    /// @notice Distributes the same amount of a fungible token from one sender to multiple receivers
+    /// @dev Optimizes gas by building a single transfer list with multiple receivers
+    /// @param token The token address to distribute
+    /// @param sender The address sending the tokens
+    /// @param receivers Array of addresses to receive the tokens
+    /// @param amount The amount each receiver should get
+    /// @return responseCode The response code from the airdrop operation (22 = success)
     function tokenAirdropDistribute(
         address token,
         address sender,
@@ -163,13 +163,13 @@ contract Airdrop is HederaTokenService {
         return responseCode;
     }
 
-    // @notice Distributes sequential NFTs from one sender to multiple receivers
-    // @dev Assigns sequential serial numbers starting from 1 to each receiver
-    // @param token The NFT token address
-    // @param sender The address sending the NFTs
-    // @param receivers Array of addresses to receive the NFTs
-    // @param serials Array of serial numbers to assign to each receiver
-    // @return responseCode The response code from the airdrop operation (22 = success)
+    /// @notice Distributes sequential NFTs from one sender to multiple receivers
+    /// @dev Assigns sequential serial numbers starting from 1 to each receiver
+    /// @param token The NFT token address
+    /// @param sender The address sending the NFTs
+    /// @param receivers Array of addresses to receive the NFTs
+    /// @param serials Array of serial numbers to assign to each receiver
+    /// @return responseCode The response code from the airdrop operation (22 = success)
     function nftAirdropDistribute(address token, address sender, address[] memory receivers, int64[] memory serials) public payable returns (int64 responseCode) {
         uint256 length = receivers.length;
         IHederaTokenService.TokenTransferList[] memory tokenTransfers = new IHederaTokenService.TokenTransferList[](1);
@@ -189,17 +189,17 @@ contract Airdrop is HederaTokenService {
         return responseCode;
     }
 
-    // @notice Performs a mixed airdrop of both fungible and non-fungible tokens
-    // @dev Combines multiple token types into a single airdropTokens call for gas efficiency
-    // @param token Array of fungible token addresses
-    // @param nft Array of NFT token addresses
-    // @param tokenSenders Array of addresses sending the fungible tokens
-    // @param tokenReceivers Array of addresses receiving the fungible tokens
-    // @param nftSenders Array of addresses sending the NFTs
-    // @param nftReceivers Array of addresses receiving the NFTs
-    // @param tokenAmount Amount of each fungible token to transfer
-    // @param serials Array of serial numbers for the NFTs
-    // @return responseCode The response code from the airdrop operation (22 = success)
+    /// @notice Performs a mixed airdrop of both fungible and non-fungible tokens
+    /// @dev Combines multiple token types into a single airdropTokens call for gas efficiency
+    /// @param token Array of fungible token addresses
+    /// @param nft Array of NFT token addresses
+    /// @param tokenSenders Array of addresses sending the fungible tokens
+    /// @param tokenReceivers Array of addresses receiving the fungible tokens
+    /// @param nftSenders Array of addresses sending the NFTs
+    /// @param nftReceivers Array of addresses receiving the NFTs
+    /// @param tokenAmount Amount of each fungible token to transfer
+    /// @param serials Array of serial numbers for the NFTs
+    /// @return responseCode The response code from the airdrop operation (22 = success)
     function mixedAirdrop(address[] memory token, address[] memory nft, address[] memory tokenSenders, address[] memory tokenReceivers, address[] memory nftSenders, address[] memory nftReceivers, int64 tokenAmount, int64[] memory serials) public payable returns (int64 responseCode) {
         uint256 length = tokenSenders.length + nftSenders.length;
         IHederaTokenService.TokenTransferList[] memory tokenTransfers = new IHederaTokenService.TokenTransferList[](length);
@@ -228,12 +228,12 @@ contract Airdrop is HederaTokenService {
         return responseCode;
     }
 
-    // @notice Internal helper to prepare AccountAmount array for token transfers
-    // @dev Creates a transfer pair with negative amount for sender and positive for receiver
-    // @param sender The address sending tokens
-    // @param receiver The address receiving tokens
-    // @param amount The amount to transfer
-    // @return transfers Array containing the sender and receiver transfer details
+    /// @notice Internal helper to prepare AccountAmount array for token transfers
+    /// @dev Creates a transfer pair with negative amount for sender and positive for receiver
+    /// @param sender The address sending tokens
+    /// @param receiver The address receiving tokens
+    /// @param amount The amount to transfer
+    /// @return transfers Array containing the sender and receiver transfer details
     function createAccountTransferPair(address sender, address receiver, int64 amount) internal pure returns (IHederaTokenService.AccountAmount[] memory transfers) {
         IHederaTokenService.AccountAmount memory aa1;
         aa1.accountID = sender;
@@ -247,12 +247,12 @@ contract Airdrop is HederaTokenService {
         return transfers;
     }
 
-    // @notice Internal helper to prepare NFT transfer struct
-    // @dev Sets up sender, receiver and serial number for an NFT transfer
-    // @param sender The address sending the NFT
-    // @param receiver The address receiving the NFT
-    // @param serial The serial number of the NFT
-    // @return nftTransfer The prepared NFT transfer struct
+    /// @notice Internal helper to prepare NFT transfer struct
+    /// @dev Sets up sender, receiver and serial number for an NFT transfer
+    /// @param sender The address sending the NFT
+    /// @param receiver The address receiving the NFT
+    /// @param serial The serial number of the NFT
+    /// @return nftTransfer The prepared NFT transfer struct
     function prepareNftTransfer(address sender, address receiver, int64 serial) internal pure returns (IHederaTokenService.NftTransfer memory nftTransfer) {
         nftTransfer.senderAccountID = sender;
         nftTransfer.receiverAccountID = receiver;

--- a/contracts/extensions/hrc-904/CancelAirdrop.sol
+++ b/contracts/extensions/hrc-904/CancelAirdrop.sol
@@ -6,22 +6,22 @@ import {HederaTokenService} from "../../token-service/HederaTokenService.sol";
 import {IHederaTokenService} from "../../token-service/IHederaTokenService.sol";
 pragma experimental ABIEncoderV2;
 
-// @title Cancel Airdrop Contract
-// @notice Facilitates cancellation of pending token airdrops on the Hedera network
-// @dev Implements HRC-904 standard for cancelling pending airdrops
-//
-// Pending airdrops can be cancelled in these cases:
-// - When receiver has "receiver signature required" enabled
-// - When receiver has no available auto-association slots
-// - Before the receiver claims the airdrop
+/// @title Cancel Airdrop Contract
+/// @notice Facilitates cancellation of pending token airdrops on the Hedera network
+/// @dev Implements HRC-904 standard for cancelling pending airdrops
+///
+/// Pending airdrops can be cancelled in these cases:
+/// - When receiver has "receiver signature required" enabled
+/// - When receiver has no available auto-association slots
+/// - Before the receiver claims the airdrop
 contract CancelAirdrop is HederaTokenService {
 
-    // @notice Cancels a pending fungible token airdrop from a sender to a receiver
-    // @dev Builds pending airdrop struct and submits cancelAirdrops system contract call
-    // @param sender The address that sent the tokens
-    // @param receiver The address that was to receive the tokens
-    // @param token The token address of the pending airdrop
-    // @return responseCode The response code from the cancel operation (22 = success)
+    /// @notice Cancels a pending fungible token airdrop from a sender to a receiver
+    /// @dev Builds pending airdrop struct and submits cancelAirdrops system contract call
+    /// @param sender The address that sent the tokens
+    /// @param receiver The address that was to receive the tokens
+    /// @param token The token address of the pending airdrop
+    /// @return responseCode The response code from the cancel operation (22 = success)
     function cancelAirdrop(address sender, address receiver, address token) public returns(int64 responseCode){
         IHederaTokenService.PendingAirdrop[] memory pendingAirdrops = new IHederaTokenService.PendingAirdrop[](1);
 
@@ -39,13 +39,13 @@ contract CancelAirdrop is HederaTokenService {
         return responseCode;
     }
 
-    // @notice Cancels a pending non-fungible token airdrop from a sender to a receiver
-    // @dev Builds pending NFT airdrop struct and submits cancelAirdrops system contract call
-    // @param sender The address that sent the NFT
-    // @param receiver The address that was to receive the NFT
-    // @param token The NFT token address
-    // @param serial The serial number of the NFT
-    // @return responseCode The response code from the cancel operation (22 = success)
+    /// @notice Cancels a pending non-fungible token airdrop from a sender to a receiver
+    /// @dev Builds pending NFT airdrop struct and submits cancelAirdrops system contract call
+    /// @param sender The address that sent the NFT
+    /// @param receiver The address that was to receive the NFT
+    /// @param token The NFT token address
+    /// @param serial The serial number of the NFT
+    /// @return responseCode The response code from the cancel operation (22 = success)
     function cancelNFTAirdrop(address sender, address receiver, address token, int64 serial) public returns(int64 responseCode){
         IHederaTokenService.PendingAirdrop[] memory pendingAirdrops = new IHederaTokenService.PendingAirdrop[](1);
 
@@ -64,13 +64,13 @@ contract CancelAirdrop is HederaTokenService {
         return responseCode;
     }
 
-    // @notice Cancels multiple pending airdrops in a single transaction
-    // @dev Builds array of pending airdrop structs and submits batch cancelAirdrops call
-    // @param senders Array of addresses that sent the tokens/NFTs
-    // @param receivers Array of addresses that were to receive the tokens/NFTs
-    // @param tokens Array of token addresses for the pending airdrops
-    // @param serials Array of serial numbers for NFT airdrops (use 0 for fungible tokens)
-    // @return responseCode The response code from the batch cancel operation (22 = success)
+    /// @notice Cancels multiple pending airdrops in a single transaction
+    /// @dev Builds array of pending airdrop structs and submits batch cancelAirdrops call
+    /// @param senders Array of addresses that sent the tokens/NFTs
+    /// @param receivers Array of addresses that were to receive the tokens/NFTs
+    /// @param tokens Array of token addresses for the pending airdrops
+    /// @param serials Array of serial numbers for NFT airdrops (use 0 for fungible tokens)
+    /// @return responseCode The response code from the batch cancel operation (22 = success)
     function cancelMultipleAirdrops(address[] memory senders, address[] memory receivers, address[] memory tokens, int64[] memory serials) public returns (int64 responseCode) {
         uint length = senders.length;
         IHederaTokenService.PendingAirdrop[] memory pendingAirdrops = new IHederaTokenService.PendingAirdrop[](length);

--- a/contracts/extensions/hrc-904/ClaimAirdrop.sol
+++ b/contracts/extensions/hrc-904/ClaimAirdrop.sol
@@ -6,22 +6,22 @@ import {HederaTokenService} from "../../token-service/HederaTokenService.sol";
 import {IHederaTokenService} from "../../token-service/IHederaTokenService.sol";
 pragma experimental ABIEncoderV2;
 
-// @title Claim Airdrop Contract
-// @notice Facilitates claiming of pending token airdrops on the Hedera network
-// @dev Implements HRC-904 standard for claiming pending airdrops
-//
-// Pending airdrops can be claimed in these cases:
-// - When receiver has "receiver signature required" enabled
-// - When receiver has no available auto-association slots
-// - After the sender has airdropped tokens but before they are cancelled
+/// @title Claim Airdrop Contract
+/// @notice Facilitates claiming of pending token airdrops on the Hedera network
+/// @dev Implements HRC-904 standard for claiming pending airdrops
+///
+/// Pending airdrops can be claimed in these cases:
+/// - When receiver has "receiver signature required" enabled
+/// - When receiver has no available auto-association slots
+/// - After the sender has airdropped tokens but before they are cancelled
 contract ClaimAirdrop is HederaTokenService {
 
-    // @notice Claims a pending fungible token airdrop sent to the caller
-    // @dev Builds pending airdrop struct and submits claimAirdrops system contract call
-    // @param sender The address that sent the tokens
-    // @param receiver The address claiming the tokens
-    // @param token The token address of the pending airdrop
-    // @return responseCode The response code from the claim operation (22 = success)
+    /// @notice Claims a pending fungible token airdrop sent to the caller
+    /// @dev Builds pending airdrop struct and submits claimAirdrops system contract call
+    /// @param sender The address that sent the tokens
+    /// @param receiver The address claiming the tokens
+    /// @param token The token address of the pending airdrop
+    /// @return responseCode The response code from the claim operation (22 = success)
     function claim(address sender, address receiver, address token) public returns(int64 responseCode){
         IHederaTokenService.PendingAirdrop[] memory pendingAirdrops = new IHederaTokenService.PendingAirdrop[](1);
 
@@ -39,13 +39,13 @@ contract ClaimAirdrop is HederaTokenService {
         return responseCode;
     }
 
-    // @notice Claims a pending non-fungible token airdrop sent to the caller
-    // @dev Builds pending NFT airdrop struct and submits claimAirdrops system contract call
-    // @param sender The address that sent the NFT
-    // @param receiver The address claiming the NFT
-    // @param token The NFT token address
-    // @param serial The serial number of the NFT
-    // @return responseCode The response code from the claim operation (22 = success)
+    /// @notice Claims a pending non-fungible token airdrop sent to the caller
+    /// @dev Builds pending NFT airdrop struct and submits claimAirdrops system contract call
+    /// @param sender The address that sent the NFT
+    /// @param receiver The address claiming the NFT
+    /// @param token The NFT token address
+    /// @param serial The serial number of the NFT
+    /// @return responseCode The response code from the claim operation (22 = success)
     function claimNFTAirdrop(address sender, address receiver, address token, int64 serial) public returns(int64 responseCode){
         IHederaTokenService.PendingAirdrop[] memory pendingAirdrops = new IHederaTokenService.PendingAirdrop[](1);
 
@@ -64,13 +64,13 @@ contract ClaimAirdrop is HederaTokenService {
         return responseCode;
     }
 
-    // @notice Claims multiple pending airdrops in a single transaction
-    // @dev Builds array of pending airdrop structs and submits batch claimAirdrops call
-    // @param senders Array of addresses that sent the tokens/NFTs
-    // @param receivers Array of addresses claiming the tokens/NFTs
-    // @param tokens Array of token addresses for the pending airdrops
-    // @param serials Array of serial numbers for NFT airdrops (use 0 for fungible tokens)
-    // @return responseCode The response code from the batch claim operation (22 = success)
+    /// @notice Claims multiple pending airdrops in a single transaction
+    /// @dev Builds array of pending airdrop structs and submits batch claimAirdrops call
+    /// @param senders Array of addresses that sent the tokens/NFTs
+    /// @param receivers Array of addresses claiming the tokens/NFTs
+    /// @param tokens Array of token addresses for the pending airdrops
+    /// @param serials Array of serial numbers for NFT airdrops (use 0 for fungible tokens)
+    /// @return responseCode The response code from the batch claim operation (22 = success)
     function claimMultipleAirdrops(address[] memory senders, address[] memory receivers, address[] memory tokens, int64[] memory serials) public returns (int64 responseCode) {
         uint length = senders.length;
         IHederaTokenService.PendingAirdrop[] memory pendingAirdrops = new IHederaTokenService.PendingAirdrop[](length);

--- a/contracts/extensions/hrc-904/TokenReject.sol
+++ b/contracts/extensions/hrc-904/TokenReject.sol
@@ -6,22 +6,22 @@ import {HederaTokenService} from "../../token-service/HederaTokenService.sol";
 import {IHederaTokenService} from "../../token-service/IHederaTokenService.sol";
 pragma experimental ABIEncoderV2;
 
-// @title Token Reject Contract
-// @notice Facilitates rejection of both fungible and non-fungible tokens on the Hedera network
-// @dev Implements token rejection functionality by building NFT structs and calling the rejectTokens system contract
-//
-// Allows accounts to reject:
-// - Multiple fungible tokens in a single transaction
-// - Multiple NFTs in a single transaction
-// - Both fungible and non-fungible tokens together
+/// @title Token Reject Contract
+/// @notice Facilitates rejection of both fungible and non-fungible tokens on the Hedera network
+/// @dev Implements token rejection functionality by building NFT structs and calling the rejectTokens system contract
+///
+/// Allows accounts to reject:
+/// - Multiple fungible tokens in a single transaction
+/// - Multiple NFTs in a single transaction
+/// - Both fungible and non-fungible tokens together
 contract TokenReject is HederaTokenService {
 
-    // @notice Rejects multiple fungible and non-fungible tokens for an account
-    // @dev Builds NFT ID structs and submits rejectTokens system contract call
-    // @param rejectingAddress The address rejecting the tokens
-    // @param ftAddresses Array of fungible token addresses to reject
-    // @param nftAddresses Array of NFT token addresses to reject
-    // @return responseCode The response code from the reject operation (22 = success)
+    /// @notice Rejects multiple fungible and non-fungible tokens for an account
+    /// @dev Builds NFT ID structs and submits rejectTokens system contract call
+    /// @param rejectingAddress The address rejecting the tokens
+    /// @param ftAddresses Array of fungible token addresses to reject
+    /// @param nftAddresses Array of NFT token addresses to reject
+    /// @return responseCode The response code from the reject operation (22 = success)
     function rejectTokens(address rejectingAddress, address[] memory ftAddresses, address[] memory nftAddresses) public returns(int64 responseCode) {
         IHederaTokenService.NftID[] memory nftIDs = new IHederaTokenService.NftID[](nftAddresses.length);
         for (uint i; i < nftAddresses.length; i++)


### PR DESCRIPTION
**Description**:

Convert the HRC-904 example doc tags from `//` to `///` so `solc` parses them as NatSpec. The tags were complete but written with two slashes, so none of the docs reached userdoc/devdoc, explorers, or IDE hovers.

  * Convert `//` doc-comment lines (`@tag` lines and their free-text continuations) to `///` in `Airdrop`, `CancelAirdrop`, `ClaimAirdrop`, and `TokenReject`
  * Leave `// SPDX-License-Identifier` lines untouched

  **Related issue(s)**:

  Fixes #127

  **Notes for reviewer**:

 Docs-only change — no runtime/ABI impact. Diff is a pure `//` → `///` swap (146 insertions / 146 deletions). Verified with `npx hardhat compile`: solc now emits `userdoc`/`devdoc` for all four contracts (e.g. `TokenReject` → contract `@notice` + 4 documented methods + 13 `@param` entries), whereas before they were empty.