### PR TITLE
chore: consistency and dead code cleanup

### DIFF
--- a/contracts/account-service/HederaAccountService.sol
+++ b/contracts/account-service/HederaAccountService.sol
@@ -80,7 +80,7 @@ abstract contract HederaAccountService {
     }
 
     /// Determines if the signature is valid for the given message hash and account.
-    /// It is assumed that the signature is composed of a single EDCSA or ED25519 key.
+    /// It is assumed that the signature is composed of a single ECDSA or ED25519 key.
     /// @param account The account to check the signature against
     /// @param messageHash The hash of the message to check the signature against
     /// @param signature The signature to check

--- a/contracts/account-service/IHRC632.sol
+++ b/contracts/account-service/IHRC632.sol
@@ -22,7 +22,7 @@ interface IHRC632 {
     function isValidAlias(address addr) external returns (bool response);
 
     /// Determines if the signature is valid for the given message hash and account.
-    /// It is assumed that the signature is composed of a single EDCSA or ED25519 key.
+    /// It is assumed that the signature is composed of a single ECDSA or ED25519 key.
     /// @param account The account to check the signature against.
     /// @param messageHash The hash of the message to check the signature against.
     /// @param signature The signature to check.

--- a/contracts/account-service/IHederaAccountService.sol
+++ b/contracts/account-service/IHederaAccountService.sol
@@ -46,7 +46,7 @@ interface IHederaAccountService {
     function isValidAlias(address addr) external returns (int64 responseCode, bool response);
 
     /// Determines if the signature is valid for the given message hash and account.
-    /// It is assumed that the signature is composed of a single EDCSA or ED25519 key.
+    /// It is assumed that the signature is composed of a single ECDSA or ED25519 key.
     /// @param account The account to check the signature against.
     /// @param messageHash The hash of the message to check the signature against.
     /// @param signature The signature to check.

--- a/contracts/exchange-rate/ExchangeRateMock.sol
+++ b/contracts/exchange-rate/ExchangeRateMock.sol
@@ -7,13 +7,13 @@ contract ExchangeRateMock is SelfFunding {
     event TinyBars(uint256 tinybars);
     event TinyCents(uint256 tinycents);
 
-    function convertTinycentsToTinybars(uint256 tineycents) external returns (uint256 tinybars) {
-        tinybars = tinycentsToTinybars(tineycents);
+    function convertTinycentsToTinybars(uint256 tinycents) external returns (uint256 tinybars) {
+        tinybars = tinycentsToTinybars(tinycents);
         emit TinyBars(tinybars);
     }
 
-    function convertTinybarsToTinycents(uint256 tinybars) external returns (uint256 tineycents) {
-        tineycents = tinybarsToTinycents(tinybars);
-        emit TinyCents(tineycents);
+    function convertTinybarsToTinycents(uint256 tinybars) external returns (uint256 tinycents) {
+        tinycents = tinybarsToTinycents(tinybars);
+        emit TinyCents(tinycents);
     }
 }

--- a/contracts/extensions/hrc-904/Airdrop.sol
+++ b/contracts/extensions/hrc-904/Airdrop.sol
@@ -94,7 +94,7 @@ contract Airdrop is HederaTokenService {
     // @param receiver The address receiving all NFTs
     // @param serials Array of serial numbers corresponding to each NFT
     // @return responseCode The response code from the airdrop operation (22 = success)
-    function multipleNftAirdrop(address[] memory nfts, address sender, address receiver, int64[] memory serials) public returns (int64 responseCode) {
+    function multipleNftAirdrop(address[] memory nfts, address sender, address receiver, int64[] memory serials) public payable returns (int64 responseCode) {
         uint256 length = nfts.length;
         IHederaTokenService.TokenTransferList[] memory tokenTransfers = new IHederaTokenService.TokenTransferList[](length);
         for (uint256 i = 0; i < length; i++)

--- a/contracts/extensions/ihrc-1215/HRC1215Contract.sol
+++ b/contracts/extensions/ihrc-1215/HRC1215Contract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.4.9 <0.9.0;
 
 import "../../schedule-service/HederaScheduleService.sol";

--- a/contracts/extensions/ihrc-755/HRC755Contract.sol
+++ b/contracts/extensions/ihrc-755/HRC755Contract.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.4.9 <0.9.0;
 
 import "../../schedule-service/HederaScheduleService.sol";
-import "../../token-service/HederaTokenService.sol";
 
 pragma experimental ABIEncoderV2;
 

--- a/contracts/extensions/token-create/TokenCreateContract.sol
+++ b/contracts/extensions/token-create/TokenCreateContract.sol
@@ -3,10 +3,9 @@ pragma solidity >=0.5.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../token-service/HederaTokenService.sol";
-import "../../token-service/ExpiryHelper.sol";
 import "../../token-service/KeyHelper.sol";
 
-contract TokenCreateContract is HederaTokenService, ExpiryHelper, KeyHelper {
+contract TokenCreateContract is HederaTokenService, KeyHelper {
 
     string name = "tokenName";
     string symbol = "tokenSymbol";

--- a/contracts/extensions/token-create/TokenCreateCustom.sol
+++ b/contracts/extensions/token-create/TokenCreateCustom.sol
@@ -3,11 +3,10 @@ pragma solidity >=0.5.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../token-service/HederaTokenService.sol";
-import "../../token-service/ExpiryHelper.sol";
 import "../../token-service/KeyHelper.sol";
 import "../../token-service/FeeHelper.sol";
 
-contract TokenCreateCustomContract is HederaTokenService, ExpiryHelper, KeyHelper, FeeHelper {
+contract TokenCreateCustomContract is HederaTokenService, KeyHelper, FeeHelper {
     bool finiteTotalSupplyType = true;
 
     event ResponseCode(int responseCode);

--- a/contracts/extensions/token-manage/TokenManagementContract.sol
+++ b/contracts/extensions/token-manage/TokenManagementContract.sol
@@ -3,11 +3,9 @@ pragma solidity >=0.5.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../token-service/HederaTokenService.sol";
-import "../../token-service/ExpiryHelper.sol";
-import "../../token-service/KeyHelper.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 
-contract TokenManagementContract is HederaTokenService, ExpiryHelper, KeyHelper {
+contract TokenManagementContract is HederaTokenService {
 
     event ResponseCode(int responseCode);
     event PausedToken(bool paused);

--- a/contracts/extensions/token-query/TokenQueryContract.sol
+++ b/contracts/extensions/token-query/TokenQueryContract.sol
@@ -3,10 +3,8 @@ pragma solidity >=0.5.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../token-service/HederaTokenService.sol";
-import "../../token-service/ExpiryHelper.sol";
-import "../../token-service/KeyHelper.sol";
 
-contract TokenQueryContract is HederaTokenService, ExpiryHelper, KeyHelper {
+contract TokenQueryContract is HederaTokenService {
 
     event ResponseCode(int responseCode);
     event AllowanceValue(uint256 amount);

--- a/contracts/extensions/token-transfer/TokenTransferContract.sol
+++ b/contracts/extensions/token-transfer/TokenTransferContract.sol
@@ -3,10 +3,8 @@ pragma solidity >=0.5.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../../token-service/HederaTokenService.sol";
-import "../../token-service/ExpiryHelper.sol";
-import "../../token-service/KeyHelper.sol";
 
-contract TokenTransferContract is HederaTokenService, ExpiryHelper, KeyHelper {
+contract TokenTransferContract is HederaTokenService {
 
     event ResponseCode(int responseCode);
 

--- a/contracts/mocks/InternalCallee.sol
+++ b/contracts/mocks/InternalCallee.sol
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-contract Sample {
-    function selfDestructSample() external {
-        selfdestruct(payable(msg.sender));
-    }
-}
+import "./Sample.sol";
 
 contract InternalCallee {
     uint public calledTimes = 0;

--- a/contracts/native/EcrecoverCaller.sol
+++ b/contracts/native/EcrecoverCaller.sol
@@ -20,9 +20,10 @@ contract EcrecoverCaller {
         return success;
     }
 
-    function send0x1() external payable {
+    function send0x1() external payable returns (bool) {
         address payable target = payable(accountZeroZeroOne);
-        target.transfer(msg.value);
+        bool success = target.send(msg.value);
+        return success;
     }
 
     function transfer0x1() external payable {

--- a/contracts/prng/PrngSystemContract.sol
+++ b/contracts/prng/PrngSystemContract.sol
@@ -3,13 +3,13 @@ pragma solidity >=0.5.0 <0.9.0;
 
 import "./IPrngSystemContract.sol";
 
-contract PrngSystemContract {
+contract PrngSystemContract is IPrngSystemContract {
     event PseudoRandomSeed(bytes32 seedBytes);
 
     // Prng system contract address with ContractID 0.0.361
     address constant PRECOMPILE_ADDRESS = address(0x169);
 
-    function getPseudorandomSeed() external returns (bytes32 seedBytes) {
+    function getPseudorandomSeed() external override returns (bytes32 seedBytes) {
         (bool success, bytes memory result) = PRECOMPILE_ADDRESS.call(
             abi.encodeWithSelector(IPrngSystemContract.getPseudorandomSeed.selector));
         require(success, "PRNG system call failed");

--- a/contracts/schedule-service/HederaScheduleService.sol
+++ b/contracts/schedule-service/HederaScheduleService.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity >=0.4.9 <0.9.0;
+pragma solidity >=0.5.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../common/HederaResponseCodes.sol";

--- a/contracts/token-service-v2/HederaTokenService.sol
+++ b/contracts/token-service-v2/HederaTokenService.sol
@@ -213,7 +213,6 @@ abstract contract HederaTokenService {
 
     /// Retrieves fungible specific token info for a fungible token
     /// @param token The ID of the token as a solidity address
-    /// @dev This function reverts if the call is not successful
     function getFungibleTokenInfo(address token) internal returns (int responseCode, IHederaTokenService.FungibleTokenInfo memory tokenInfo) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getFungibleTokenInfo.selector, token));
@@ -223,7 +222,6 @@ abstract contract HederaTokenService {
 
     /// Retrieves general token info for a given token
     /// @param token The ID of the token as a solidity address
-    /// @dev This function reverts if the call is not successful
     function getTokenInfo(address token) internal returns (int responseCode, IHederaTokenService.TokenInfo memory tokenInfo) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getTokenInfo.selector, token));
@@ -233,7 +231,6 @@ abstract contract HederaTokenService {
 
     /// Retrieves non-fungible specific token info for a given NFT
     /// @param token The ID of the token as a solidity address
-    /// @dev This function reverts if the call is not successful
     function getNonFungibleTokenInfo(address token, int64 serialNumber) internal returns (int responseCode, IHederaTokenService.NonFungibleTokenInfo memory tokenInfo) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getNonFungibleTokenInfo.selector, token, serialNumber));
@@ -247,7 +244,6 @@ abstract contract HederaTokenService {
     /// @return fixedFees Set of fixed fees for `token`
     /// @return fractionalFees Set of fractional fees for `token`
     /// @return royaltyFees Set of royalty fees for `token`
-    /// @dev This function reverts if the call is not successful
     function getTokenCustomFees(address token) internal returns (int64 responseCode,
         IHederaTokenService.FixedFee[] memory fixedFees,
         IHederaTokenService.FractionalFee[] memory fractionalFees,
@@ -359,7 +355,6 @@ abstract contract HederaTokenService {
     /// @param account The account address associated with the token
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return frozen True if `account` is frozen for `token`
-    /// @dev This function reverts if the call is not successful
     function isFrozen(address token, address account) internal returns (int64 responseCode, bool frozen){
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.isFrozen.selector, token, account));
@@ -371,7 +366,6 @@ abstract contract HederaTokenService {
     /// @param account The account address associated with the token
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return kycGranted True if `account` has kyc granted for `token`
-    /// @dev This function reverts if the call is not successful
     function isKyc(address token, address account) internal returns (int64 responseCode, bool kycGranted){
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.isKyc.selector, token, account));
@@ -454,7 +448,6 @@ abstract contract HederaTokenService {
     /// @param token The token address to check
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return defaultFreezeStatus True if `token` default freeze status is frozen.
-    /// @dev This function reverts if the call is not successful
     function getTokenDefaultFreezeStatus(address token) internal returns (int responseCode, bool defaultFreezeStatus) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getTokenDefaultFreezeStatus.selector, token));
@@ -465,7 +458,6 @@ abstract contract HederaTokenService {
     /// @param token The token address to check
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return defaultKycStatus True if `token` default kyc status is KycNotApplicable and false if Revoked.
-    /// @dev This function reverts if the call is not successful
     function getTokenDefaultKycStatus(address token) internal returns (int responseCode, bool defaultKycStatus) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getTokenDefaultKycStatus.selector, token));
@@ -606,7 +598,6 @@ abstract contract HederaTokenService {
     /// @param keyType The keyType of the desired KeyValue
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return key KeyValue info for key of type `keyType`
-    /// @dev This function reverts if the call is not successful
     function getTokenKey(address token, uint keyType)
     internal returns (int64 responseCode, IHederaTokenService.KeyValue memory key){
         (bool success, bytes memory result) = precompileAddress.call(
@@ -620,7 +611,6 @@ abstract contract HederaTokenService {
     /// @param token The token address
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return isTokenFlag True if valid token found for the given address
-    /// @dev This function reverts if the call is not successful
     function isToken(address token) internal returns (int64 responseCode, bool isTokenFlag) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.isToken.selector, token));
@@ -631,7 +621,6 @@ abstract contract HederaTokenService {
     /// @param token The token address
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return tokenType the token type. 0 is FUNGIBLE_COMMON, 1 is NON_FUNGIBLE_UNIQUE, -1 is UNRECOGNIZED
-    /// @dev This function reverts if the call is not successful
     function getTokenType(address token) internal returns (int64 responseCode, int32 tokenType) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getTokenType.selector, token));
@@ -642,7 +631,6 @@ abstract contract HederaTokenService {
     /// @param token The token address
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return expiryInfo The expiry info of the token
-    /// @dev This function reverts if the call is not successful
     function getTokenExpiryInfo(address token) internal returns (int responseCode, IHederaTokenService.Expiry memory expiryInfo){
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getTokenExpiryInfo.selector, token));

--- a/contracts/token-service-v2/KeyHelper.sol
+++ b/contracts/token-service-v2/KeyHelper.sol
@@ -27,7 +27,7 @@ abstract contract KeyHelper {
         CONTRACT_ID,
         ED25519,
         SECP256K1,
-        DELEGETABLE_CONTRACT_ID
+        DELEGATABLE_CONTRACT_ID
     }
 
     constructor() {
@@ -112,7 +112,7 @@ abstract contract KeyHelper {
             keyValue.ed25519 = key;
         } else if (keyValueType == KeyValueType.SECP256K1) {
             keyValue.ECDSA_secp256k1 = key;
-        } else if (keyValueType == KeyValueType.DELEGETABLE_CONTRACT_ID) {
+        } else if (keyValueType == KeyValueType.DELEGATABLE_CONTRACT_ID) {
             keyValue.delegatableContractId = supplyContract;
         }
     }
@@ -120,7 +120,7 @@ abstract contract KeyHelper {
     function getKeyValueType(KeyValueType keyValueType, address keyAddress) internal pure returns (IHederaTokenService.KeyValue memory keyValue) {
         if (keyValueType == KeyValueType.CONTRACT_ID) {
             keyValue.contractId = keyAddress;
-        } else if (keyValueType == KeyValueType.DELEGETABLE_CONTRACT_ID) {
+        } else if (keyValueType == KeyValueType.DELEGATABLE_CONTRACT_ID) {
             keyValue.delegatableContractId = keyAddress;
         }
     }

--- a/contracts/token-service/AtomicHTS.sol
+++ b/contracts/token-service/AtomicHTS.sol
@@ -50,11 +50,11 @@ contract AtomicHTS is HederaTokenService {
      *
      * @notice because .approve() can only grant allowances to spender on behalf of the caller, and in this case
      *         `this contract` is the caller who makes transactions to the `precompile contract`. With the same reason,
-     *         .transferFrom() will transfer the tokens from token owner to the receipient by the spender (this contract)
+     *         .transferFrom() will transfer the tokens from token owner to the recipient by the spender (this contract)
      *         on behalf of the token owner. Therefore, the spender in this particular case will also be the sender whose balance
      *         will be deducted by the .transferFrom() method.
      */
-    function batchApproveAssociateGrantKYCTransferFrom(address token, address owner, address receipient, int64 transferAmount, uint256 allowance) external {
+    function batchApproveAssociateGrantKYCTransferFrom(address token, address owner, address recipient, int64 transferAmount, uint256 allowance) external {
         
         /// top up the spender with initial fund
         /// @notice it is necessary for the spender to be associated and granted token KYC to receive fund. 
@@ -77,17 +77,17 @@ contract AtomicHTS is HederaTokenService {
         (int approveResponseCode) = HederaTokenService.approve(token, spender, allowance);
         require(approveResponseCode == HederaResponseCodes.SUCCESS, "Failed to grant token allowance.");
 
-        (int associateResponseCode) = HederaTokenService.associateToken(receipient, token);
+        (int associateResponseCode) = HederaTokenService.associateToken(recipient, token);
         require(
             associateResponseCode == HederaResponseCodes.SUCCESS || 
             associateResponseCode == HederaResponseCodes.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT, 
             "Failed to associate token."
         );
 
-        (int grantKYCResponseCode) = HederaTokenService.grantTokenKyc(token, receipient); 
+        (int grantKYCResponseCode) = HederaTokenService.grantTokenKyc(token, recipient); 
         require(grantKYCResponseCode == HederaResponseCodes.SUCCESS, "Failed to grant token KYC.");
 
-        (int transferFromResponseCode) = this.transferFrom(token, spender, receipient, allowance);
+        (int transferFromResponseCode) = this.transferFrom(token, spender, recipient, allowance);
         require(transferFromResponseCode == HederaResponseCodes.SUCCESS, "Failed to transfer token.");
 
         emit BatchApproveAssociateGrantKYCTransferFrom(transferTokenResponseCode, approveResponseCode, associateResponseCode, grantKYCResponseCode, transferFromResponseCode);

--- a/contracts/token-service/HederaTokenService.sol
+++ b/contracts/token-service/HederaTokenService.sol
@@ -213,7 +213,6 @@ abstract contract HederaTokenService {
 
     /// Retrieves fungible specific token info for a fungible token
     /// @param token The ID of the token as a solidity address
-    /// @dev This function reverts if the call is not successful
     function getFungibleTokenInfo(address token) internal returns (int responseCode, IHederaTokenService.FungibleTokenInfo memory tokenInfo) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getFungibleTokenInfo.selector, token));
@@ -223,7 +222,6 @@ abstract contract HederaTokenService {
 
     /// Retrieves general token info for a given token
     /// @param token The ID of the token as a solidity address
-    /// @dev This function reverts if the call is not successful
     function getTokenInfo(address token) internal returns (int responseCode, IHederaTokenService.TokenInfo memory tokenInfo) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getTokenInfo.selector, token));
@@ -233,7 +231,6 @@ abstract contract HederaTokenService {
 
     /// Retrieves non-fungible specific token info for a given NFT
     /// @param token The ID of the token as a solidity address
-    /// @dev This function reverts if the call is not successful
     function getNonFungibleTokenInfo(address token, int64 serialNumber) internal returns (int responseCode, IHederaTokenService.NonFungibleTokenInfo memory tokenInfo) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getNonFungibleTokenInfo.selector, token, serialNumber));
@@ -247,7 +244,6 @@ abstract contract HederaTokenService {
     /// @return fixedFees Set of fixed fees for `token`
     /// @return fractionalFees Set of fractional fees for `token`
     /// @return royaltyFees Set of royalty fees for `token`
-    /// @dev This function reverts if the call is not successful
     function getTokenCustomFees(address token) internal returns (int64 responseCode,
         IHederaTokenService.FixedFee[] memory fixedFees,
         IHederaTokenService.FractionalFee[] memory fractionalFees,
@@ -359,7 +355,6 @@ abstract contract HederaTokenService {
     /// @param account The account address associated with the token
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return frozen True if `account` is frozen for `token`
-    /// @dev This function reverts if the call is not successful
     function isFrozen(address token, address account) internal returns (int64 responseCode, bool frozen){
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.isFrozen.selector, token, account));
@@ -371,7 +366,6 @@ abstract contract HederaTokenService {
     /// @param account The account address associated with the token
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return kycGranted True if `account` has kyc granted for `token`
-    /// @dev This function reverts if the call is not successful
     function isKyc(address token, address account) internal returns (int64 responseCode, bool kycGranted){
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.isKyc.selector, token, account));
@@ -454,7 +448,6 @@ abstract contract HederaTokenService {
     /// @param token The token address to check
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return defaultFreezeStatus True if `token` default freeze status is frozen.
-    /// @dev This function reverts if the call is not successful
     function getTokenDefaultFreezeStatus(address token) internal returns (int responseCode, bool defaultFreezeStatus) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getTokenDefaultFreezeStatus.selector, token));
@@ -465,7 +458,6 @@ abstract contract HederaTokenService {
     /// @param token The token address to check
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return defaultKycStatus True if `token` default kyc status is KycNotApplicable and false if Revoked.
-    /// @dev This function reverts if the call is not successful
     function getTokenDefaultKycStatus(address token) internal returns (int responseCode, bool defaultKycStatus) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getTokenDefaultKycStatus.selector, token));
@@ -606,7 +598,6 @@ abstract contract HederaTokenService {
     /// @param keyType The keyType of the desired KeyValue
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return key KeyValue info for key of type `keyType`
-    /// @dev This function reverts if the call is not successful
     function getTokenKey(address token, uint keyType)
     internal returns (int64 responseCode, IHederaTokenService.KeyValue memory key){
         (bool success, bytes memory result) = precompileAddress.call(
@@ -620,7 +611,6 @@ abstract contract HederaTokenService {
     /// @param token The token address
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return isTokenFlag True if valid token found for the given address
-    /// @dev This function reverts if the call is not successful
     function isToken(address token) internal returns (int64 responseCode, bool isTokenFlag) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.isToken.selector, token));
@@ -631,7 +621,6 @@ abstract contract HederaTokenService {
     /// @param token The token address
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return tokenType the token type. 0 is FUNGIBLE_COMMON, 1 is NON_FUNGIBLE_UNIQUE, -1 is UNRECOGNIZED
-    /// @dev This function reverts if the call is not successful
     function getTokenType(address token) internal returns (int64 responseCode, int32 tokenType) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getTokenType.selector, token));
@@ -642,7 +631,6 @@ abstract contract HederaTokenService {
     /// @param token The token address
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return expiryInfo The expiry info of the token
-    /// @dev This function reverts if the call is not successful
     function getTokenExpiryInfo(address token) internal returns (int responseCode, IHederaTokenService.Expiry memory expiryInfo){
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getTokenExpiryInfo.selector, token));

--- a/contracts/token-service/KeyHelper.sol
+++ b/contracts/token-service/KeyHelper.sol
@@ -24,7 +24,7 @@ abstract contract KeyHelper {
         CONTRACT_ID,
         ED25519,
         SECP256K1,
-        DELEGETABLE_CONTRACT_ID
+        DELEGATABLE_CONTRACT_ID
     }
 
     constructor() {
@@ -137,7 +137,7 @@ abstract contract KeyHelper {
             keyValue.ed25519 = key;
         } else if (keyValueType == KeyValueType.SECP256K1) {
             keyValue.ECDSA_secp256k1 = key;
-        } else if (keyValueType == KeyValueType.DELEGETABLE_CONTRACT_ID) {
+        } else if (keyValueType == KeyValueType.DELEGATABLE_CONTRACT_ID) {
             keyValue.delegatableContractId = supplyContract;
         }
     }
@@ -149,7 +149,7 @@ abstract contract KeyHelper {
     {
         if (keyValueType == KeyValueType.CONTRACT_ID) {
             keyValue.contractId = keyAddress;
-        } else if (keyValueType == KeyValueType.DELEGETABLE_CONTRACT_ID) {
+        } else if (keyValueType == KeyValueType.DELEGATABLE_CONTRACT_ID) {
             keyValue.delegatableContractId = keyAddress;
         }
     }


### PR DESCRIPTION
**Description**:

Resolve two batches of non-behavioral cleanup across the reference contracts: consistency/dead-code issues (#129) and identifier/doc typos plus one misnamed function (#128). Nothing changes on-chain behavior except the single, isolated `send0x1` fix noted below. Delivered as two commits, one per issue.

**#129 — consistency & dead code:**

* Remove the inaccurate `/// @dev This function reverts if the call is not successful` comment from the non-reverting info getters in `token-service/HederaTokenService.sol` and `token-service-v2/HederaTokenService.sol` (12 each — the wrappers return `UNKNOWN`, they don't revert)
* Fix `HRC1215Contract.sol` license `UNLICENSED` → `Apache-2.0`
* Raise `HederaScheduleService.sol` pragma `>=0.4.9` → `>=0.5.0` (required by its `abi.decode` usage)
* Make `PrngSystemContract` inherit its interface (`is IPrngSystemContract` + `override`)
* Add `payable` to `Airdrop.multipleNftAirdrop` for parity with the other airdrop entrypoints
* Remove the duplicate `contract Sample` from `InternalCallee.sol` and import the canonical `Sample.sol` (artifact-name collision)
* Drop unused imports / inheritance: `HederaTokenService` from `HRC755Contract`; `ExpiryHelper`+`KeyHelper` from `TokenQuery`/`TokenTransfer`/`TokenManagement`; `ExpiryHelper` from `TokenCreateContract`/`TokenCreateCustom`

**#128 — identifier/doc typos + misnamed function:**

* Fix enum `DELEGETABLE_CONTRACT_ID` → `DELEGATABLE_CONTRACT_ID` in `token-service/KeyHelper.sol` and `token-service-v2/KeyHelper.sol`
* Fix `EDCSA` → `ECDSA` in `account-service/{IHRC632,HederaAccountService,IHederaAccountService}.sol`
* Fix `tineycents` → `tinycents` in `exchange-rate/ExchangeRateMock.sol`
* Fix `receipient` → `recipient` in `token-service/AtomicHTS.sol`
* Make `EcrecoverCaller.send0x1` actually use `.send()` (returning the success bool) instead of `.transfer()`, so it's genuinely distinct from `transfer0x1`

**Related issue(s)**:

Fixes #129
Fixes #128

**Notes for reviewer**:

Verified with `npx hardhat compile` (clean, 64 files, no new warnings). 21 files changed across two commits. The CI lint (`eslint .` + `prettier test`) doesn't touch Solidity, so no formatting impact.

Scope / behavior notes worth a look:

* **`send0x1` is the only behavioral change in either issue.** `.transfer()` reverts on failure; `.send()` returns a bool and does not revert. The function now returns that bool and deliberately does **not** `revert()` on failure (that non-reverting behavior is the point of `.send` vs `.transfer`). It has no callers/tests in the repo, so nothing depends on the old behavior.
* **Enum rename is a source-level breaking change.** `DELEGETABLE_CONTRACT_ID` → `DELEGATABLE_CONTRACT_ID` does not change the enum's on-wire integer value, but downstream code referencing the old (misspelled) name will no longer compile.
* **#129 Item C narrowed to Prng only.** The issue also listed `ExchangeRateSystemContract`/`ExchangeRateMock` and `HederaAccountService`, but those can't inherit their imported interface: it's the *precompile's ABI* (used only for `.selector`), and their wrappers are `internal` while the interface functions are `external` — an internal function can't satisfy an external interface, so it wouldn't compile and is semantically backwards (they're consumers, not implementations). Only `PrngSystemContract` is a genuine implementer.
* **#129 Item F broadened; AtomicHTS pragma dropped.** `TokenCreateContract`/`TokenCreateCustom` also carried dead `ExpiryHelper` inheritance (they use `KeyHelper`, never `ExpiryHelper`), so those were included. `ExpiryHelper.sol` now has no importers but is intentionally **kept** — it's a published helper (part of the `ExpiryHelper`/`FeeHelper`/`KeyHelper` set), so deleting it would be a breaking change to the published surface. The issue's proposed AtomicHTS pragma change was dropped: there's no single project-wide pragma rule (`>=0.5.0 <0.9.0` and `>=0.4.9 <0.9.0` are tied within `token-service/`), so it would have been arbitrary rather than an alignment.
