### PR TITLE
fix: parametrize NFT serial in TokenReject.rejectTokens

### DIFF
--- a/contracts/extensions/hrc-904/TokenReject.sol
+++ b/contracts/extensions/hrc-904/TokenReject.sol
@@ -21,14 +21,15 @@ contract TokenReject is HederaTokenService {
     // @param rejectingAddress The address rejecting the tokens
     // @param ftAddresses Array of fungible token addresses to reject
     // @param nftAddresses Array of NFT token addresses to reject
+    // @param serials Array of serial numbers corresponding to each NFT in nftAddresses
     // @return responseCode The response code from the reject operation (22 = success)
-    function rejectTokens(address rejectingAddress, address[] memory ftAddresses, address[] memory nftAddresses) public returns(int64 responseCode) {
+    function rejectTokens(address rejectingAddress, address[] memory ftAddresses, address[] memory nftAddresses, int64[] memory serials) public returns(int64 responseCode) {
         IHederaTokenService.NftID[] memory nftIDs = new IHederaTokenService.NftID[](nftAddresses.length);
         for (uint i; i < nftAddresses.length; i++)
         {
             IHederaTokenService.NftID memory nftId;
             nftId.nft = nftAddresses[i];
-            nftId.serial = 1;
+            nftId.serial = serials[i];
             nftIDs[i] = nftId;
         }
         responseCode = rejectTokens(rejectingAddress, ftAddresses, nftIDs);

--- a/test/token-service/hrc-904/TokenRejectContract.js
+++ b/test/token-service/hrc-904/TokenRejectContract.js
@@ -91,6 +91,7 @@ describe('HIP904Batch3 TokenRejectContract Test Suite', function () {
       receiver.address,
       [tokenAddress],
       [],
+      [],
       Constants.GAS_LIMIT_2_000_000,
     );
     const responseCode = await utils.getHTSResponseCode(tx.hash);
@@ -106,7 +107,10 @@ describe('HIP904Batch3 TokenRejectContract Test Suite', function () {
     );
     const receiver = signers[1];
 
-    const serial = utils.mintNFTToAddress(tokenCreateContract, nftTokenAddress);
+    const serial = await utils.mintNFTToAddress(
+      tokenCreateContract,
+      nftTokenAddress,
+    );
 
     const airdropTx = await airdropContract.nftAirdrop(
       nftTokenAddress,
@@ -128,6 +132,52 @@ describe('HIP904Batch3 TokenRejectContract Test Suite', function () {
       receiver.address,
       [],
       [nftTokenAddress],
+      [serial],
+      Constants.GAS_LIMIT_2_000_000,
+    );
+    const responseCode = await utils.getHTSResponseCode(tx.hash);
+    expect(responseCode).to.eq('22'); // SUCCESS code
+  });
+
+  it('should reject a specific NFT serial when more than one has been minted', async function () {
+    const nftTokenAddress = await utils.setupNft(
+      tokenCreateContract,
+      owner,
+      contractAddresses,
+      hapi,
+    );
+    const receiver = signers[1];
+
+    // Mint two NFTs and reject the SECOND serial. A regression to a hardcoded
+    // serial (e.g. the previous `nftId.serial = 1`) would fail this case.
+    await utils.mintNFTToAddress(tokenCreateContract, nftTokenAddress);
+    const secondSerial = await utils.mintNFTToAddress(
+      tokenCreateContract,
+      nftTokenAddress,
+    );
+    expect(secondSerial).to.eq(2);
+
+    const airdropTx = await airdropContract.nftAirdrop(
+      nftTokenAddress,
+      owner,
+      receiver.address,
+      secondSerial,
+      {
+        value: Constants.ONE_HBAR,
+        gasLimit: 2_000_000,
+      },
+    );
+    await airdropTx.wait();
+
+    await walletIHRC904AccountFacade.setUnlimitedAutomaticAssociations(true, {
+      gasLimit: 2_000_000,
+    });
+
+    const tx = await tokenRejectContract.rejectTokens(
+      receiver.address,
+      [],
+      [nftTokenAddress],
+      [secondSerial],
       Constants.GAS_LIMIT_2_000_000,
     );
     const responseCode = await utils.getHTSResponseCode(tx.hash);
@@ -159,6 +209,7 @@ describe('HIP904Batch3 TokenRejectContract Test Suite', function () {
       const tx = await tokenRejectContract.rejectTokens(
         receiver.address,
         [tokenAddress],
+        [],
         [],
         Constants.GAS_LIMIT_2_000_000,
       );
@@ -195,6 +246,7 @@ describe('HIP904Batch3 TokenRejectContract Test Suite', function () {
       receiver.address,
       [tokenAddress],
       [],
+      [],
       Constants.GAS_LIMIT_2_000_000,
     );
     const responseCode = await utils.getHTSResponseCode(tx.hash);
@@ -214,6 +266,7 @@ describe('HIP904Batch3 TokenRejectContract Test Suite', function () {
       receiver.address,
       [tokenAddress],
       [],
+      [],
       Constants.GAS_LIMIT_2_000_000,
     );
     const responseCode = await utils.getHTSResponseCode(tx.hash);
@@ -229,10 +282,13 @@ describe('HIP904Batch3 TokenRejectContract Test Suite', function () {
       hapi,
     );
 
+    // Fails on the invalid fungible token before the NFT serial is evaluated,
+    // so the serial value here is irrelevant (placeholder to match array length).
     const tx = await tokenRejectContract.rejectTokens(
       receiver.address,
       [invalidToken],
       [nftTokenAddress],
+      [1],
       Constants.GAS_LIMIT_2_000_000,
     );
     const responseCode = await utils.getHTSResponseCode(tx.hash);
@@ -250,7 +306,10 @@ describe('HIP904Batch3 TokenRejectContract Test Suite', function () {
     );
     const receiver = signers[1];
 
-    const serial = utils.mintNFTToAddress(tokenCreateContract, nftTokenAddress);
+    const serial = await utils.mintNFTToAddress(
+      tokenCreateContract,
+      nftTokenAddress,
+    );
 
     const airdropTx = await airdropContract.nftAirdrop(
       nftTokenAddress,
@@ -272,6 +331,7 @@ describe('HIP904Batch3 TokenRejectContract Test Suite', function () {
       receiver.address,
       [],
       [invalidNft],
+      [serial],
       Constants.GAS_LIMIT_2_000_000,
     );
     const responseCode = await utils.getHTSResponseCode(tx.hash);


### PR DESCRIPTION
**Description**:

`TokenReject.rejectTokens` hardcoded `nftId.serial = 1`, so the example could only ever reject serial `#1` of each NFT collection — any other serial was unreachable, and the limitation was invisible to the test suite (it only ever minted one fresh NFT, which is always serial 1).

* Add an `int64[] serials` parameter to `rejectTokens` and use `nftId.serial = serials[i]` (mirroring `cancelMultipleAirdrops` / `claimMultipleAirdrops`)
* Update the existing test call sites to pass the new `serials` array
* Add a regression test that mints two NFTs and rejects serial `#2`, so the missing-serial limitation cannot silently return
* Fix two `mintNFTToAddress` calls in the test that were missing `await` (they returned Promises and "worked" only because the reject was hardcoded to serial 1)

**Related issue(s)**:

Fixes #123

**Notes for reviewer**:

This is a **breaking ABI change** — `rejectTokens` gains a parameter, so its selector changes. That's inherent to the fix (the serial must be caller-supplied). The `serials` array is expected to be parallel to `nftAddresses`; there's no explicit length guard, matching the sibling multi-airdrop helpers (out-of-bounds already reverts at the EVM level).

Verified: `npx hardhat compile` clean (64 files); the rewritten test passes Prettier and ESLint. The regression test asserts the second minted serial is `2` (`setupNft` creates a fresh collection and does not pre-mint, so sequential mints yield 1 then 2) and rejects serial `#2` — which the previous hardcoded-`1` code could not do. The acceptance suite runs against a live Hedera node (`solo`), so runtime confirmation is via CI, not local.
