### PR TITLE
fix: check responseCode on mint/transfer in token-create examples

### DIFF
--- a/contracts/extensions/hip-1028/HIP1028Contract.sol
+++ b/contracts/extensions/hip-1028/HIP1028Contract.sol
@@ -8,6 +8,8 @@ import "../../token-service-v2/KeyHelper.sol";
 import "../../token-service-v2/FeeHelper.sol";
 
 contract HIP1028Contract is HederaTokenService, KeyHelper, FeeHelper {
+    error TokenMintFailed(int responseCode);
+
     event TokenAddress(address);
     event TokenInfo(IHederaTokenService.TokenInfo);
     event FungibleTokenInfo(IHederaTokenService.FungibleTokenInfo);
@@ -180,7 +182,10 @@ contract HIP1028Contract is HederaTokenService, KeyHelper, FeeHelper {
 
         createdAddress = tokenAddress;
 
-        HederaTokenService.mintToken(createdAddress, 0, new bytes[](1));
+        (responseCode, , ) = HederaTokenService.mintToken(createdAddress, 0, new bytes[](1));
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert TokenMintFailed(responseCode);
+        }
 
         emit TokenAddress(createdAddress);
     }

--- a/contracts/extensions/token-create/TokenCreateContract.sol
+++ b/contracts/extensions/token-create/TokenCreateContract.sol
@@ -83,8 +83,8 @@ contract TokenCreateContract is HederaTokenService, ExpiryHelper, KeyHelper {
         return tokenAddress;
     }
 
-    function createFungibleTokenWithSECP256K1AdminKeyAssociateAndTransferToAddressPublic(address treasury, bytes memory adminKey, int64 amount) public payable {
-        address tokenAddress = this.createFungibleTokenWithSECP256K1AdminKeyPublic{value : msg.value}(treasury, adminKey);
+    function createFungibleTokenWithSECP256K1AdminKeyAssociateAndTransferToAddressPublic(address /* treasury */, bytes memory adminKey, int64 amount) public payable {
+        address tokenAddress = this.createFungibleTokenWithSECP256K1AdminKeyPublic{value : msg.value}(address(this), adminKey);
         this.associateTokenPublic(msg.sender, tokenAddress);
         this.grantTokenKycPublic(tokenAddress, msg.sender);
         int responseCode = HederaTokenService.transferToken(tokenAddress, address(this), msg.sender, amount);

--- a/contracts/extensions/token-create/TokenCreateContract.sol
+++ b/contracts/extensions/token-create/TokenCreateContract.sol
@@ -17,6 +17,8 @@ contract TokenCreateContract is HederaTokenService, ExpiryHelper, KeyHelper {
     bool freezeDefaultStatus = false;
     bool finiteTotalSupplyType = true;
 
+    error TokenTransferFailed(int responseCode);
+
     event ResponseCode(int responseCode);
     event CreatedToken(address tokenAddress);
     event MintedToken(int64 newTotalSupply, int64[] serialNumbers);
@@ -85,7 +87,10 @@ contract TokenCreateContract is HederaTokenService, ExpiryHelper, KeyHelper {
         address tokenAddress = this.createFungibleTokenWithSECP256K1AdminKeyPublic{value : msg.value}(treasury, adminKey);
         this.associateTokenPublic(msg.sender, tokenAddress);
         this.grantTokenKycPublic(tokenAddress, msg.sender);
-        HederaTokenService.transferToken(tokenAddress, address(this), msg.sender, amount);
+        int responseCode = HederaTokenService.transferToken(tokenAddress, address(this), msg.sender, amount);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert TokenTransferFailed(responseCode);
+        }
     }
 
     function createFungibleTokenWithSECP256K1AdminKeyWithoutKYCPublic(
@@ -291,7 +296,10 @@ contract TokenCreateContract is HederaTokenService, ExpiryHelper, KeyHelper {
 
         emit MintedToken(newTotalSupply, serialNumbers);
 
-        HederaTokenService.transferNFT(token, address(this), msg.sender, serialNumbers[0]);
+        responseCode = HederaTokenService.transferNFT(token, address(this), msg.sender, serialNumbers[0]);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert TokenTransferFailed(responseCode);
+        }
     }
 
     function associateTokensPublic(address account, address[] memory tokens) external returns (int256 responseCode) {

--- a/contracts/extensions/token-create/TokenCreateCustom.sol
+++ b/contracts/extensions/token-create/TokenCreateCustom.sol
@@ -10,6 +10,8 @@ import "../../token-service/FeeHelper.sol";
 contract TokenCreateCustomContract is HederaTokenService, ExpiryHelper, KeyHelper, FeeHelper {
     bool finiteTotalSupplyType = true;
 
+    error TokenTransferFailed(int responseCode);
+
     event ResponseCode(int responseCode);
     event CreatedToken(address tokenAddress);
     event TransferToken(address tokenAddress, address receiver, int64 amount);
@@ -179,7 +181,10 @@ contract TokenCreateCustomContract is HederaTokenService, ExpiryHelper, KeyHelpe
     returns (int responseCode, int64 newTotalSupply, int64[] memory serialNumbers)  {
         (responseCode, newTotalSupply, serialNumbers) = mintTokenPublic(token, amount, metadata);
 
-        HederaTokenService.transferToken(token, address(this), receiver, amount);
+        responseCode = HederaTokenService.transferToken(token, address(this), receiver, amount);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert TokenTransferFailed(responseCode);
+        }
         emit TransferToken(token, receiver, amount);
     }
 
@@ -187,7 +192,10 @@ contract TokenCreateCustomContract is HederaTokenService, ExpiryHelper, KeyHelpe
     returns (int responseCode, int64 newTotalSupply, int64[] memory serialNumbers)  {
         (responseCode, newTotalSupply, serialNumbers) = mintTokenPublic(token, amount, metadata);
 
-        HederaTokenService.transferNFT(token, address(this), receiver, serialNumbers[0]);
+        responseCode = HederaTokenService.transferNFT(token, address(this), receiver, serialNumbers[0]);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert TokenTransferFailed(responseCode);
+        }
         emit TransferToken(token, receiver, amount);
     }
 


### PR DESCRIPTION
**Description**:

Two related fixes to the token-create examples, shipped together because they compound on the same `associate-and-transfer` flow.

**#124 — check ignored `responseCode`:** `mintToken` / `transferToken` / `transferNFT` return a non-`SUCCESS` code on failure instead of reverting, and these examples ignored it — so failed native ops passed silently.

* Capture and check `responseCode` at the 5 ignored sites (`HIP1028Contract` mint; `TokenCreateContract` transferToken/transferNFT; `TokenCreateCustom` transferToken/transferNFT)
* Revert with custom errors carrying the code — `TokenMintFailed(int)` / `TokenTransferFailed(int)` — instead of bare `revert()`

**#125 — transfer from contract-as-treasury:** `createFungibleTokenWithSECP256K1AdminKeyAssociateAndTransferToAddressPublic` minted supply to the caller-supplied `treasury` but transferred from `address(this)`, so the transfer failed whenever `treasury != address(this)`.

* Pass `address(this)` into the create sub-call so the contract is the treasury and the transfer has a valid source
* Keep the signature (param name commented out) — non-breaking, ABI/selector unchanged

Together: #125 makes the transfer succeed; #124 makes any remaining failure loud instead of silent.

**Related issue(s)**:

Fixes #124
Fixes #125

**Notes for reviewer**:

Compiles clean (64 files, no new warnings). Single-copy example contracts, so no v2 mirror. Two scope notes:

* **Intentional in-file inconsistency (#124):** only the 5 mint/transfer checks use custom errors; the pre-existing `create` / `associate` / `update` / `approve` checks keep bare `revert()` — converting all ~38 was left out of scope.
* No test changes; only `mintTokenToAddressPublic` is test-exercised (happy path via `utils.mintNFTToAddress`), so added reverts don't affect passing tests. Runtime confirmation is via CI (acceptance suite needs a live `solo` node).
