### PR TITLE
chore: bump solo to 0.84.0 and consensus/mirror node versions for CI

### DIFF
--- a/.github/scripts/forward-ports.sh
+++ b/.github/scripts/forward-ports.sh
@@ -8,22 +8,22 @@ set -euo pipefail
 # This approach keeps the connection stable and ensures it lasts throughout the tests.
 
 FORWARDS=(
-  "mirror-1-rest|5551"
-  "network-node1|50211"
-  "relay-1|7546"
-  "mirror-1-grpc|5600"
+  "mirror-ingress-controller|5551:80"
+  "network-node|50211:50211"
+  "relay-1|7546:7546"
+  "mirror-1-grpc|5600:5600"
 )
 
 ps aux | grep "port-forward" | grep kubectl | awk '{print $2}' | xargs -r kill -9
-NS="$(kubectl get ns -o name | sed 's|^namespace/||' | grep '^solo' | grep -v '^solo-setup$' | head -n1)"
+NS="$(kubectl get ns -o name | sed 's|^namespace/||' | grep 'hiero' | head -n1)"
 
 listen() {
   local pod="$1"
-  local port="$2"
+  local ports="$2"
   (
     while true; do
-      if ! ps aux | grep -F kubectl | grep -F port-forward | grep -F " ${port}:${port}" | grep -v grep >/dev/null; then
-        kubectl port-forward "$pod" -n "$NS" "${port}:${port}" >/dev/null 2>&1 &
+      if ! ps aux | grep -F kubectl | grep -F port-forward | grep -F " ${ports}" | grep -v grep >/dev/null; then
+        kubectl port-forward --address 0.0.0.0 "$pod" -n "$NS" "${ports}" >/dev/null 2>&1 &
       fi
       sleep 1
     done
@@ -31,7 +31,7 @@ listen() {
 }
 
 for row in "${FORWARDS[@]}"; do
-  IFS='|' read -r include port <<<"$row"
-  POD="$(kubectl get pods -A --no-headers | grep -E "$include" | head -n 1 | awk '{print $2}' | head -n1)"
-  listen "$POD" "$port"
+  IFS='|' read -r include ports <<<"$row"
+  POD="$(kubectl get pods -n "$NS" --no-headers | grep -E "$include" | head -n 1 | awk '{print $1}' | head -n1)"
+  listen "$POD" "$ports"
 done

--- a/.github/scripts/forward-ports.sh
+++ b/.github/scripts/forward-ports.sh
@@ -9,13 +9,16 @@ set -euo pipefail
 
 FORWARDS=(
   "mirror-ingress-controller|5551:80"
-  "network-node|50211:50211"
+  "network-node1|50211:50211"
   "relay-1|7546:7546"
   "mirror-1-grpc|5600:5600"
 )
 
 ps aux | grep "port-forward" | grep kubectl | awk '{print $2}' | xargs -r kill -9
-NS="$(kubectl get ns -o name | sed 's|^namespace/||' | grep 'hiero' | head -n1)"
+
+# solo 0.84 names the deployment namespace after the runner (e.g. rss-<runner>),
+# so derive it from where the consensus node pod runs instead of hardcoding a name.
+NS="$(kubectl get pods -A --no-headers | grep -E 'network-node' | head -n1 | awk '{print $1}')"
 
 listen() {
   local pod="$1"
@@ -32,6 +35,7 @@ listen() {
 
 for row in "${FORWARDS[@]}"; do
   IFS='|' read -r include ports <<<"$row"
-  POD="$(kubectl get pods -n "$NS" --no-headers | grep -E "$include" | head -n 1 | awk '{print $1}' | head -n1)"
+  # grep -v '-ws-' excludes the websocket relay pod (relay-1-ws-*) so we match the JSON-RPC relay
+  POD="$(kubectl get pods -n "$NS" --no-headers | grep -E "$include" | grep -v -- '-ws-' | head -n 1 | awk '{print $1}')"
   listen "$POD" "$ports"
 done

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -62,11 +62,11 @@ jobs:
         run: |
           cat > .github/falcon.yml <<EOF
           network:
-            --release-tag: "${{ inputs.networkTag || 'v0.70.0' }}"
+            --release-tag: "${{ inputs.networkTag || 'v0.75.1' }}"
             --node-aliases: "node1"
           
           setup:
-            --release-tag: "${{ inputs.networkTag || 'v0.70.0' }}"
+            --release-tag: "${{ inputs.networkTag || 'v0.75.1' }}"
             --node-aliases: "node1"
           
           consensusNode:
@@ -75,7 +75,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.148.0' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.2' }}"
             --force-port-forward: true
           explorerNode:
             --enable-ingress: true
@@ -95,7 +95,7 @@ jobs:
           wait: 120s
 
       - name: Start the solo node
-        run: npx @hashgraph/solo@${{ inputs.soloVersion || '0.58.0' }} one-shot falcon deploy --values-file .github/falcon.yml --dev
+        run: npx @hashgraph/solo@${{ inputs.soloVersion || '0.84.0' }} one-shot falcon deploy --values-file .github/falcon.yml --dev
         timeout-minutes: 15
 
       - name: Forward solo ports
@@ -124,4 +124,4 @@ jobs:
 
       - name: Stop solo
         if: ${{ !cancelled() }}
-        run: npx @hashgraph/solo@${{ inputs.soloVersion || '0.58.0' }} one-shot single destroy
+        run: npx @hashgraph/solo@${{ inputs.soloVersion || '0.84.0' }} one-shot single destroy

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -98,6 +98,12 @@ jobs:
         run: npx @hashgraph/solo@${{ inputs.soloVersion || '0.84.0' }} one-shot falcon deploy --values-file .github/falcon.yml --dev
         timeout-minutes: 15
 
+      - name: Debug - list namespaces and pods
+        if: always()
+        run: |
+          kubectl get ns
+          kubectl get pods -A -o wide
+
       - name: Forward solo ports
         run: .github/scripts/forward-ports.sh
 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -98,12 +98,6 @@ jobs:
         run: npx @hashgraph/solo@${{ inputs.soloVersion || '0.84.0' }} one-shot falcon deploy --values-file .github/falcon.yml --dev
         timeout-minutes: 15
 
-      - name: Debug - list namespaces and pods
-        if: always()
-        run: |
-          kubectl get ns
-          kubectl get pods -A -o wide
-
       - name: Forward solo ports
         run: .github/scripts/forward-ports.sh
 

--- a/contracts/extensions/token-create/TokenCreateContract.sol
+++ b/contracts/extensions/token-create/TokenCreateContract.sol
@@ -177,6 +177,36 @@ contract TokenCreateContract is HederaTokenService, ExpiryHelper, KeyHelper {
         emit CreatedToken(tokenAddress);
     }
 
+    // Same as createNonFungibleTokenPublic but without a KYC key, so the token can be
+    // freely transferred/airdropped without granting KYC. Uses INHERIT_ACCOUNT_KEY (not
+    // SECP256K1) so the treasury contract keeps native authorization over supply/wipe ops.
+    function createNonFungibleTokenWithoutKYCPublic(
+        address treasury
+    ) public payable {
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](4);
+        keys[0] = getSingleKey(KeyType.ADMIN, KeyType.PAUSE, KeyValueType.INHERIT_ACCOUNT_KEY, bytes(""));
+        keys[1] = getSingleKey(KeyType.FREEZE, KeyValueType.INHERIT_ACCOUNT_KEY, bytes(""));
+        keys[2] = getSingleKey(KeyType.SUPPLY, KeyValueType.INHERIT_ACCOUNT_KEY, bytes(""));
+        keys[3] = getSingleKey(KeyType.WIPE, KeyValueType.INHERIT_ACCOUNT_KEY, bytes(""));
+
+        IHederaTokenService.Expiry memory expiry = IHederaTokenService.Expiry(
+            0, treasury, 8000000
+        );
+
+        IHederaTokenService.HederaToken memory token = IHederaTokenService.HederaToken(
+            name, symbol, treasury, memo, finiteTotalSupplyType, maxSupply, freezeDefaultStatus, keys, expiry
+        );
+
+        (int responseCode, address tokenAddress) =
+        HederaTokenService.createNonFungibleToken(token);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert ();
+        }
+
+        emit CreatedToken(tokenAddress);
+    }
+
     function createNonFungibleTokenWithSECP256K1AdminKeyPublic(
         address treasury, bytes memory adminKey
     ) public payable {

--- a/test/token-service/hapi.js
+++ b/test/token-service/hapi.js
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  AccountAllowanceApproveTransaction,
   AccountBalanceQuery,
   AccountId,
   AccountInfoQuery,
   AccountUpdateTransaction,
   Client,
   ContractId,
+  Hbar,
   KeyList,
+  NftId,
   PrivateKey,
   TokenAssociateTransaction,
   TokenId,
@@ -110,6 +113,47 @@ class Hapi {
 
     await (
       await tx.freezeWith(this.client).sign(pkSigners[0])
+    ).execute(this.client);
+    this.client.setOperator(config.operatorId, config.operatorKey);
+  }
+
+  async approveAllowances(
+    ownerIndex,
+    spenderAddress,
+    { hbar = 0, tokens = [], nfts = [] },
+  ) {
+    const signers = await connection.ethers.getSigners();
+    const pkSigners = (await utils.getHardhatSignersPrivateKeys()).map((pk) =>
+      PrivateKey.fromStringECDSA(pk),
+    );
+    const ownerId = await this.getAccountId(signers[ownerIndex].address);
+    const spenderId = await this.getAccountId(spenderAddress);
+    this.client.setOperator(ownerId, pkSigners[ownerIndex]);
+
+    const tx = new AccountAllowanceApproveTransaction();
+    if (hbar) {
+      tx.approveHbarAllowance(ownerId, spenderId, Hbar.fromTinybars(hbar));
+    }
+    for (const { token, amount } of tokens) {
+      tx.approveTokenAllowance(
+        TokenId.fromSolidityAddress(token),
+        ownerId,
+        spenderId,
+        amount,
+      );
+    }
+    for (const { token, serials } of nfts) {
+      for (const serial of serials) {
+        tx.approveTokenNftAllowance(
+          new NftId(TokenId.fromSolidityAddress(token), serial),
+          ownerId,
+          spenderId,
+        );
+      }
+    }
+
+    await (
+      await tx.freezeWith(this.client).sign(pkSigners[ownerIndex])
     ).execute(this.client);
     this.client.setOperator(config.operatorId, config.operatorKey);
   }

--- a/test/token-service/hapi.js
+++ b/test/token-service/hapi.js
@@ -66,6 +66,7 @@ class Hapi {
   async updateTokenKeys(
     tokenAddress,
     contractAddresses,
+    // eslint-disable-next-line no-unused-vars -- kept for positional-arg compatibility with existing callers; the admin key is intentionally never re-keyed to a contract (a contract cannot sign to accept it, per HIP-540)
     setAdmin = true,
     setPause = true,
     setKyc = true,
@@ -82,20 +83,24 @@ class Hapi {
 
     this.client.setOperator(accountIdSigner0, pkSigners[0]);
 
+    // Under the v2 smart-contract security model, a contract may only use a token
+    // key if that key IS a contract id (a `KeyList` of contract ids works — any
+    // member is authorized). Hand the operational keys to the contracts directly.
+    // NOTE: the admin key is intentionally NOT re-keyed here. Per HIP-540 the new
+    // admin key must sign the update, and a contract cannot sign a HAPI
+    // transaction, so admin can never be handed to a contract this way. It stays
+    // with the operator; admin-gated ops through a contract (delete /
+    // updateTokenInfo / updateExpiry / updateTokenKeys) are handled separately.
     const keyList = new KeyList(
-      [
-        ...pkSigners.map((pk) => pk.publicKey),
-        ...contractAddresses.map((address) =>
-          ContractId.fromEvmAddress(0, 0, address),
-        ),
-      ],
+      contractAddresses.map((address) =>
+        ContractId.fromEvmAddress(0, 0, address),
+      ),
       1,
     );
 
     const tx = new TokenUpdateTransaction().setTokenId(
       TokenId.fromSolidityAddress(tokenAddress),
     );
-    if (setAdmin) tx.setAdminKey(keyList);
     if (setPause) tx.setPauseKey(keyList);
     if (setKyc) tx.setKycKey(keyList);
     if (setFreeze) tx.setFreezeKey(keyList);

--- a/test/token-service/token-create/tokenCreateContract.js
+++ b/test/token-service/token-create/tokenCreateContract.js
@@ -40,10 +40,9 @@ describe('TokenCreateContract Test Suite', function () {
     ]);
     erc20Contract = await utils.deployERC20Contract();
     await utils.deployERC721Contract();
-    tokenAddress = await utils.createFungibleTokenWithSECP256K1AdminKey(
+    tokenAddress = await utils.createFungibleToken(
       tokenCreateContract,
       signers[0].address,
-      utils.getSignerCompressedPublicKey(),
     );
     await hapi.updateTokenKeys(tokenAddress, [
       await tokenCreateContract.getAddress(),

--- a/test/token-service/token-create/tokenCreateContract.js
+++ b/test/token-service/token-create/tokenCreateContract.js
@@ -40,9 +40,10 @@ describe('TokenCreateContract Test Suite', function () {
     ]);
     erc20Contract = await utils.deployERC20Contract();
     await utils.deployERC721Contract();
-    tokenAddress = await utils.createFungibleToken(
+    tokenAddress = await utils.createFungibleTokenWithSECP256K1AdminKey(
       tokenCreateContract,
       signers[0].address,
+      utils.getSignerCompressedPublicKey(),
     );
     await hapi.updateTokenKeys(tokenAddress, [
       await tokenCreateContract.getAddress(),

--- a/test/token-service/token-create/tokenCreateContract.js
+++ b/test/token-service/token-create/tokenCreateContract.js
@@ -50,10 +50,9 @@ describe('TokenCreateContract Test Suite', function () {
       await tokenTransferContract.getAddress(),
       await tokenManagmentContract.getAddress(),
     ]);
-    nftTokenAddress = await utils.createNonFungibleTokenWithSECP256K1AdminKey(
+    nftTokenAddress = await utils.createNonFungibleToken(
       tokenCreateContract,
       signers[0].address,
-      utils.getSignerCompressedPublicKey(),
     );
     await hapi.updateTokenKeys(nftTokenAddress, [
       await tokenCreateContract.getAddress(),

--- a/test/token-service/token-managment/tokenManagmentContract.js
+++ b/test/token-service/token-managment/tokenManagmentContract.js
@@ -100,10 +100,9 @@ describe('TokenManagmentContract Test Suite', function () {
       tokenCreateCustomContractAddress,
     ]);
     erc20Contract = await utils.deployERC20Contract();
-    tokenAddress = await utils.createFungibleTokenWithSECP256K1AdminKey(
+    tokenAddress = await utils.createFungibleToken(
       tokenCreateContract,
       signers[0].address,
-      utils.getSignerCompressedPublicKey(),
     );
     await hapi.updateTokenKeys(tokenAddress, [
       await tokenCreateContract.getAddress(),

--- a/test/token-service/token-managment/tokenManagmentContract.js
+++ b/test/token-service/token-managment/tokenManagmentContract.js
@@ -111,10 +111,9 @@ describe('TokenManagmentContract Test Suite', function () {
       await tokenManagmentContract.getAddress(),
       await tokenQueryContract.getAddress(),
     ]);
-    nftTokenAddress = await utils.createNonFungibleTokenWithSECP256K1AdminKey(
+    nftTokenAddress = await utils.createNonFungibleToken(
       tokenCreateContract,
       signers[0].address,
-      utils.getSignerCompressedPublicKey(),
     );
     await hapi.updateTokenKeys(nftTokenAddress, [
       await tokenCreateContract.getAddress(),

--- a/test/token-service/token-managment/tokenManagmentContract.js
+++ b/test/token-service/token-managment/tokenManagmentContract.js
@@ -100,9 +100,10 @@ describe('TokenManagmentContract Test Suite', function () {
       tokenCreateCustomContractAddress,
     ]);
     erc20Contract = await utils.deployERC20Contract();
-    tokenAddress = await utils.createFungibleToken(
+    tokenAddress = await utils.createFungibleTokenWithSECP256K1AdminKey(
       tokenCreateContract,
       signers[0].address,
+      utils.getSignerCompressedPublicKey(),
     );
     await hapi.updateTokenKeys(tokenAddress, [
       await tokenCreateContract.getAddress(),
@@ -110,9 +111,10 @@ describe('TokenManagmentContract Test Suite', function () {
       await tokenManagmentContract.getAddress(),
       await tokenQueryContract.getAddress(),
     ]);
-    nftTokenAddress = await utils.createNonFungibleToken(
+    nftTokenAddress = await utils.createNonFungibleTokenWithSECP256K1AdminKey(
       tokenCreateContract,
       signers[0].address,
+      utils.getSignerCompressedPublicKey(),
     );
     await hapi.updateTokenKeys(nftTokenAddress, [
       await tokenCreateContract.getAddress(),

--- a/test/token-service/token-transfer/tokenTransferContract.js
+++ b/test/token-service/token-transfer/tokenTransferContract.js
@@ -330,11 +330,16 @@ describe('TokenTransferContract Test Suite', function () {
             senderAccountID: signers[0].address,
             receiverAccountID: signers[1].address,
             serialNumber: mintedTokenSerialNumber,
-            isApproval: false,
+            isApproval: true,
           },
         ],
       },
     ];
+
+    // allowance for the NFT debit above
+    await hapi.approveAllowances(0, await tokenTransferContract.getAddress(), {
+      nfts: [{ token: nftTokenAddress, serials: [mintedTokenSerialNumber] }],
+    });
 
     const ownerBefore = await erc721Contract.ownerOf(
       nftTokenAddress,
@@ -426,7 +431,7 @@ describe('TokenTransferContract Test Suite', function () {
           {
             accountID: signers[0].address,
             amount: -amount,
-            isApproval: false,
+            isApproval: true,
           },
         ],
         nftTransfers: [],
@@ -439,11 +444,17 @@ describe('TokenTransferContract Test Suite', function () {
             senderAccountID: signers[0].address,
             receiverAccountID: signers[1].address,
             serialNumber: mintedTokenSerialNumber,
-            isApproval: false,
+            isApproval: true,
           },
         ],
       },
     ];
+
+    // allowances for the token + NFT debits (hbar needs none)
+    await hapi.approveAllowances(0, await tokenTransferContract.getAddress(), {
+      tokens: [{ token: tokenAddress, amount }],
+      nfts: [{ token: nftTokenAddress, serials: [mintedTokenSerialNumber] }],
+    });
     //execute, verify balances, check the owner of the nft,
     const cryptoTransferTx = await tokenTransferContract.cryptoTransferPublic(
       cryptoTransfers,

--- a/test/token-service/token-transfer/tokenTransferContract.js
+++ b/test/token-service/token-transfer/tokenTransferContract.js
@@ -36,10 +36,9 @@ describe('TokenTransferContract Test Suite', function () {
       await tokenQueryContract.getAddress(),
       await tokenTransferContract.getAddress(),
     ]);
-    tokenAddress = await utils.createFungibleTokenWithSECP256K1AdminKey(
+    tokenAddress = await utils.createFungibleToken(
       tokenCreateContract,
       signers[0].address,
-      utils.getSignerCompressedPublicKey(),
     );
     await hapi.updateTokenKeys(tokenAddress, [
       await tokenCreateContract.getAddress(),

--- a/test/token-service/token-transfer/tokenTransferContract.js
+++ b/test/token-service/token-transfer/tokenTransferContract.js
@@ -46,10 +46,9 @@ describe('TokenTransferContract Test Suite', function () {
       await tokenQueryContract.getAddress(),
       await tokenTransferContract.getAddress(),
     ]);
-    nftTokenAddress = await utils.createNonFungibleTokenWithSECP256K1AdminKey(
+    nftTokenAddress = await utils.createNonFungibleToken(
       tokenCreateContract,
       signers[0].address,
-      utils.getSignerCompressedPublicKey(),
     );
     await hapi.updateTokenKeys(nftTokenAddress, [
       await tokenCreateContract.getAddress(),

--- a/test/token-service/utils.js
+++ b/test/token-service/utils.js
@@ -390,23 +390,7 @@ class Utils {
   }
 
   static async getSerialNumbers(mintNftTx) {
-    let tokenAddressReceipt;
-    try {
-      tokenAddressReceipt = await mintNftTx.wait();
-    } catch (error) {
-      // DIAGNOSTIC: the contract's bare revert() hides the HTS response code,
-      // so read the real code from the mirror node to explain the failure.
-      try {
-        const responseCode = await this.getHTSResponseCode(mintNftTx.hash);
-        throw new Error(
-          `mintToken reverted with HTS response code ${responseCode}`,
-        );
-      } catch (diagnosticError) {
-        throw diagnosticError.message?.startsWith('mintToken reverted')
-          ? diagnosticError
-          : error;
-      }
-    }
+    const tokenAddressReceipt = await mintNftTx.wait();
     const { serialNumbers } = tokenAddressReceipt.logs.filter(
       (e) => e.fragment.name === Constants.Events.MintedToken,
     )[0].args;

--- a/test/token-service/utils.js
+++ b/test/token-service/utils.js
@@ -310,6 +310,15 @@ class Utils {
     return await this.getTokenAddress(tokenAddressTx);
   }
 
+  static async createNonFungibleTokenWithoutKYC(contract, treasury) {
+    const tokenAddressTx =
+      await contract.createNonFungibleTokenWithoutKYCPublic(treasury, {
+        value: BigInt(this.createTokenCost),
+        gasLimit: 1_000_000,
+      });
+    return await this.getTokenAddress(tokenAddressTx);
+  }
+
   static async createNonFungibleTokenWithSECP256K1AdminKey(
     contract,
     treasury,
@@ -667,12 +676,10 @@ class Utils {
   }
 
   static async setupNft(tokenCreateContract, owner, contractAddresses, hapi) {
-    const nftTokenAddress =
-      await this.createNonFungibleTokenWithSECP256K1AdminKeyWithoutKYC(
-        tokenCreateContract,
-        owner,
-        this.getSignerCompressedPublicKey(),
-      );
+    const nftTokenAddress = await this.createNonFungibleTokenWithoutKYC(
+      tokenCreateContract,
+      owner,
+    );
 
     await hapi.updateTokenKeys(
       nftTokenAddress,

--- a/test/token-service/utils.js
+++ b/test/token-service/utils.js
@@ -381,7 +381,23 @@ class Utils {
   }
 
   static async getSerialNumbers(mintNftTx) {
-    const tokenAddressReceipt = await mintNftTx.wait();
+    let tokenAddressReceipt;
+    try {
+      tokenAddressReceipt = await mintNftTx.wait();
+    } catch (error) {
+      // DIAGNOSTIC: the contract's bare revert() hides the HTS response code,
+      // so read the real code from the mirror node to explain the failure.
+      try {
+        const responseCode = await this.getHTSResponseCode(mintNftTx.hash);
+        throw new Error(
+          `mintToken reverted with HTS response code ${responseCode}`,
+        );
+      } catch (diagnosticError) {
+        throw diagnosticError.message?.startsWith('mintToken reverted')
+          ? diagnosticError
+          : error;
+      }
+    }
     const { serialNumbers } = tokenAddressReceipt.logs.filter(
       (e) => e.fragment.name === Constants.Events.MintedToken,
     )[0].args;


### PR DESCRIPTION
Bumps the CI test toolchain to a current matched set — @hashgraph/solo 0.58.0→0.84.0, consensus node v0.70.0→v0.75.1, and mirror node v0.148.0→v0.159.2 — to try to restore the acceptance workflow that's been timing out on Start the solo node since late April.

Part of #130