### PR TITLE
feat: change visibility of `transferFrom`, `transferFromNFT`, `redirectForToken` and `updateNFTsMetadata`

### DIFF
--- a/contracts/extensions/token-create/TokenCreateContract.sol
+++ b/contracts/extensions/token-create/TokenCreateContract.sol
@@ -339,4 +339,8 @@ contract TokenCreateContract is HederaTokenService, ExpiryHelper, KeyHelper {
             revert ();
         }
     }
+
+    function redirectForTokenPublic(address token, bytes memory encodedFunctionSelector) external returns (int responseCode, bytes memory response) {
+        (responseCode, response) = HederaTokenService.redirectForToken(token, encodedFunctionSelector);
+    }
 }

--- a/contracts/extensions/token-transfer/TokenTransferContract.sol
+++ b/contracts/extensions/token-transfer/TokenTransferContract.sol
@@ -56,7 +56,7 @@ contract TokenTransferContract is HederaTokenService, ExpiryHelper, KeyHelper {
     }
 
     function transferFromPublic(address token, address from, address to, uint256 amount) public returns (int64 responseCode) {
-        responseCode = this.transferFrom(token, from, to, amount);
+        responseCode = HederaTokenService.transferFrom(token, from, to, amount);
         emit ResponseCode(responseCode);
 
         if (responseCode != HederaResponseCodes.SUCCESS) {
@@ -65,7 +65,7 @@ contract TokenTransferContract is HederaTokenService, ExpiryHelper, KeyHelper {
     }
 
     function transferFromNFTPublic(address token, address from, address to, uint256 serialNumber) public returns (int64 responseCode) {
-        responseCode = this.transferFromNFT(token, from, to, serialNumber);
+        responseCode = HederaTokenService.transferFromNFT(token, from, to, serialNumber);
         emit ResponseCode(responseCode);
 
         if (responseCode != HederaResponseCodes.SUCCESS) {

--- a/contracts/token-service-v2/HederaTokenService.sol
+++ b/contracts/token-service-v2/HederaTokenService.sol
@@ -286,7 +286,7 @@ abstract contract HederaTokenService {
     /// @param to The account address of the receiver of the `amount` tokens
     /// @param amount The amount of tokens to transfer from `from` to `to`
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
-    function transferFrom(address token, address from, address to, uint256 amount) external returns (int64 responseCode)
+    function transferFrom(address token, address from, address to, uint256 amount) internal returns (int64 responseCode)
     {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.transferFrom.selector,
@@ -301,7 +301,7 @@ abstract contract HederaTokenService {
     /// @param to The account address of the receiver of `serialNumber`
     /// @param serialNumber The NFT serial number to transfer
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
-    function transferFromNFT(address token, address from, address to, uint256 serialNumber) external returns (int64 responseCode)
+    function transferFromNFT(address token, address from, address to, uint256 serialNumber) internal returns (int64 responseCode)
     {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.transferFromNFT.selector,
@@ -674,7 +674,7 @@ abstract contract HederaTokenService {
     /// @param encodedFunctionSelector The function selector from the ERC20 interface + the bytes input for the function called
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return response The result of the call that had been encoded and sent for execution.
-    function redirectForToken(address token, bytes memory encodedFunctionSelector) external returns (int responseCode, bytes memory response) {
+    function redirectForToken(address token, bytes memory encodedFunctionSelector) internal returns (int responseCode, bytes memory response) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.redirectForToken.selector, token, encodedFunctionSelector)
         );
@@ -747,7 +747,7 @@ abstract contract HederaTokenService {
         (responseCode) = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
     }
 
-    function updateNFTsMetadata(address nftToken, int64[] memory serialNumbers, bytes memory metadata) external returns (int64 responseCode) {
+    function updateNFTsMetadata(address nftToken, int64[] memory serialNumbers, bytes memory metadata) internal returns (int64 responseCode) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.updateNFTsMetadata.selector, nftToken, serialNumbers, metadata)
         );

--- a/contracts/token-service/AtomicHTS.sol
+++ b/contracts/token-service/AtomicHTS.sol
@@ -87,7 +87,7 @@ contract AtomicHTS is HederaTokenService {
         (int grantKYCResponseCode) = HederaTokenService.grantTokenKyc(token, receipient); 
         require(grantKYCResponseCode == HederaResponseCodes.SUCCESS, "Failed to grant token KYC.");
 
-        (int transferFromResponseCode) = this.transferFrom(token, spender, receipient, allowance);
+        (int transferFromResponseCode) = HederaTokenService.transferFrom(token, spender, receipient, allowance);
         require(transferFromResponseCode == HederaResponseCodes.SUCCESS, "Failed to transfer token.");
 
         emit BatchApproveAssociateGrantKYCTransferFrom(transferTokenResponseCode, approveResponseCode, associateResponseCode, grantKYCResponseCode, transferFromResponseCode);

--- a/contracts/token-service/HederaTokenService.sol
+++ b/contracts/token-service/HederaTokenService.sol
@@ -286,7 +286,7 @@ abstract contract HederaTokenService {
     /// @param to The account address of the receiver of the `amount` tokens
     /// @param amount The amount of tokens to transfer from `from` to `to`
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
-    function transferFrom(address token, address from, address to, uint256 amount) external returns (int64 responseCode)
+    function transferFrom(address token, address from, address to, uint256 amount) internal returns (int64 responseCode)
     {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.transferFrom.selector,
@@ -301,7 +301,7 @@ abstract contract HederaTokenService {
     /// @param to The account address of the receiver of `serialNumber`
     /// @param serialNumber The NFT serial number to transfer
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
-    function transferFromNFT(address token, address from, address to, uint256 serialNumber) external returns (int64 responseCode)
+    function transferFromNFT(address token, address from, address to, uint256 serialNumber) internal returns (int64 responseCode)
     {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.transferFromNFT.selector,
@@ -674,7 +674,7 @@ abstract contract HederaTokenService {
     /// @param encodedFunctionSelector The function selector from the ERC20 interface + the bytes input for the function called
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return response The result of the call that had been encoded and sent for execution.
-    function redirectForToken(address token, bytes memory encodedFunctionSelector) external returns (int responseCode, bytes memory response) {
+    function redirectForToken(address token, bytes memory encodedFunctionSelector) internal returns (int responseCode, bytes memory response) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.redirectForToken.selector, token, encodedFunctionSelector)
         );

--- a/test/token-service/hrc-719/HRC719Contract.js
+++ b/test/token-service/hrc-719/HRC719Contract.js
@@ -185,7 +185,7 @@ describe('@HRC-719 Test Suite', function () {
   describe('redirectoForToken', () => {
     it('should be able to execute associate() via redirectForToken', async function () {
       const encodedFunc = IHRC719.encodeFunctionData('associate()');
-      const tx = await tokenCreateContract.redirectForToken(
+      const tx = await tokenCreateContract.redirectForTokenPublic(
         tokenAddress,
         encodedFunc,
         Constants.GAS_LIMIT_1_000_000,
@@ -198,7 +198,7 @@ describe('@HRC-719 Test Suite', function () {
     it('should be able to execute dissociate() via redirectForToken', async function () {
       // first associate the token before dissociate other wise get response_code = 184 instead of 22 (success)
       const encodedFuncAssociate = IHRC719.encodeFunctionData('associate()');
-      const associateTx = await tokenCreateContract.redirectForToken(
+      const associateTx = await tokenCreateContract.redirectForTokenPublic(
         tokenAddress,
         encodedFuncAssociate,
         Constants.GAS_LIMIT_1_000_000,
@@ -206,7 +206,7 @@ describe('@HRC-719 Test Suite', function () {
       await associateTx.wait();
 
       const enCodedFuncDissociate = IHRC719.encodeFunctionData('dissociate()');
-      const dissociateTx = await tokenCreateContract.redirectForToken(
+      const dissociateTx = await tokenCreateContract.redirectForTokenPublic(
         tokenAddress,
         enCodedFuncDissociate,
         Constants.GAS_LIMIT_1_000_000,
@@ -219,7 +219,7 @@ describe('@HRC-719 Test Suite', function () {
 
     it('should be able to execute isAssociated() via redirectForToken', async function () {
       const encodedFunc = IHRC719.encodeFunctionData('isAssociated()');
-      const tx = await tokenCreateContract.redirectForToken(
+      const tx = await tokenCreateContract.redirectForTokenPublic(
         tokenAddress,
         encodedFunc,
         Constants.GAS_LIMIT_1_000_000,
@@ -231,7 +231,7 @@ describe('@HRC-719 Test Suite', function () {
 
     it('should be able to execute isAssociated() after association via redirectForToken', async function () {
       await (
-        await tokenCreateContract.redirectForToken(
+        await tokenCreateContract.redirectForTokenPublic(
           tokenAddress,
           IHRC719.encodeFunctionData('associate()'),
           Constants.GAS_LIMIT_1_000_000,
@@ -239,7 +239,7 @@ describe('@HRC-719 Test Suite', function () {
       ).wait();
 
       const encodedFunc = IHRC719.encodeFunctionData('isAssociated()');
-      const tx = await tokenCreateContract.redirectForToken(
+      const tx = await tokenCreateContract.redirectForTokenPublic(
         tokenAddress,
         encodedFunc,
         Constants.GAS_LIMIT_1_000_000,

--- a/test/token-service/redirect-for-token.js
+++ b/test/token-service/redirect-for-token.js
@@ -88,7 +88,7 @@ describe('RedirectForToken Test Suite', function () {
 
   it('should be able to execute name()', async function () {
     const encodedFunc = IERC20.encodeFunctionData('name()');
-    const tx = await tokenCreateContract.redirectForToken(
+    const tx = await tokenCreateContract.redirectForTokenPublic(
       tokenAddress,
       encodedFunc,
     );
@@ -99,7 +99,7 @@ describe('RedirectForToken Test Suite', function () {
 
   it('should be able to execute symbol()', async function () {
     const encodedFunc = IERC20.encodeFunctionData('symbol()');
-    const tx = await tokenCreateContract.redirectForToken(
+    const tx = await tokenCreateContract.redirectForTokenPublic(
       tokenAddress,
       encodedFunc,
     );
@@ -110,7 +110,7 @@ describe('RedirectForToken Test Suite', function () {
 
   it('should be able to execute decimals()', async function () {
     const encodedFunc = IERC20.encodeFunctionData('decimals()');
-    const tx = await tokenCreateContract.redirectForToken(
+    const tx = await tokenCreateContract.redirectForTokenPublic(
       tokenAddress,
       encodedFunc,
     );
@@ -121,7 +121,7 @@ describe('RedirectForToken Test Suite', function () {
 
   it('should be able to execute totalSupply()', async function () {
     const encodedFunc = IERC20.encodeFunctionData('totalSupply()');
-    const tx = await tokenCreateContract.redirectForToken(
+    const tx = await tokenCreateContract.redirectForTokenPublic(
       tokenAddress,
       encodedFunc,
     );
@@ -134,7 +134,7 @@ describe('RedirectForToken Test Suite', function () {
     const encodedFuncSigner0 = IERC20.encodeFunctionData('balanceOf(address)', [
       signers[0].address,
     ]);
-    const tx0 = await tokenCreateContract.redirectForToken(
+    const tx0 = await tokenCreateContract.redirectForTokenPublic(
       tokenAddress,
       encodedFuncSigner0,
     );
@@ -145,7 +145,7 @@ describe('RedirectForToken Test Suite', function () {
     const encodedFuncSigner1 = IERC20.encodeFunctionData('balanceOf(address)', [
       signers[1].address,
     ]);
-    const tx1 = await tokenCreateContract.redirectForToken(
+    const tx1 = await tokenCreateContract.redirectForTokenPublic(
       tokenAddress,
       encodedFuncSigner1,
     );
@@ -159,7 +159,7 @@ describe('RedirectForToken Test Suite', function () {
       signers[1].address,
       amount,
     ]);
-    const tx = await tokenCreateContract.redirectForToken(
+    const tx = await tokenCreateContract.redirectForTokenPublic(
       tokenAddress,
       encodedFunc,
       Constants.GAS_LIMIT_10_000_000,
@@ -173,7 +173,7 @@ describe('RedirectForToken Test Suite', function () {
       'allowance(address,address)',
       [await tokenCreateContract.getAddress(), signers[1].address],
     );
-    const tx = await tokenCreateContract.redirectForToken(
+    const tx = await tokenCreateContract.redirectForTokenPublic(
       tokenAddress,
       encodedFunc,
       Constants.GAS_LIMIT_10_000_000,
@@ -198,7 +198,7 @@ describe('RedirectForToken Test Suite', function () {
       signers[1].address,
       amount,
     ]);
-    const tx = await tokenCreateContract.redirectForToken(
+    const tx = await tokenCreateContract.redirectForTokenPublic(
       tokenAddress,
       encodedFunc,
     );
@@ -237,7 +237,7 @@ describe('RedirectForToken Test Suite', function () {
       'transferFrom(address,address,uint256)',
       [await tokenCreateContract.getAddress(), signers[1].address, amount],
     );
-    const tx = await tokenCreateContract.redirectForToken(
+    const tx = await tokenCreateContract.redirectForTokenPublic(
       tokenAddress,
       encodedFunc,
       Constants.GAS_LIMIT_1_000_000,


### PR DESCRIPTION
**Description**:


Change visibility of `transferFrom` (L289), `transferFromNFT` (L304), `redirectForToken` (L677) to internal in `HederaTokenService..sol`


**Solution**:

Changes the visibility of three helpers in HederaTokenService from external to internal:

- transferFrom (L289)
- transferFromNFT (L304)
- redirectForToken (L677)

Updates the in-repo call sites that invoked them via this. (external self-call),
which will not compile once the functions are internal:
- AtomicHTS.sol L90
- examples/token-transfer/TokenTransferContract.sol L59, L68

Notes

- No change to the underlying HTS precompile calls; only visibility and the
    internal call syntax.
- redirectForToken has no internal self-call sites, so no call-site change is
    needed for it.
- token-service-v2 / updateNFTsMetadata are not present at this ref; if the
    fix also targets v2, that file needs the same visibility change in the same PR.


Two possible scope additions:
- token-service-v2 has the same three functions plus a fourth, updateNFTsMetadata.
- Three call sites need to change in the same PR or the build breaks, since this. self-calls won't compile against internal: examples/token-transfer/TokenTransferContract.sol L59 and L68, and AtomicHTS.sol L90. Nothing calls this.redirectForToken.

**Related issue(s)**:

Fixes #138 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
